### PR TITLE
remove use of onUpdateTitle

### DIFF
--- a/src/editors/document/org/OrgEditor.tsx
+++ b/src/editors/document/org/OrgEditor.tsx
@@ -317,17 +317,12 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
   }
 
   renderDetails() {
-    const { onUpdateTitle } = this.props;
-
     return (
       <div className="org-tab">
         <Details
           editMode={this.props.editMode}
           model={this.props.model}
-          onEdit={(model) => {
-            onUpdateTitle({ id: model.get('id'), title: model.get('title') });
-            this.handleEdit(model);
-          }}/>
+          onEdit={model => this.handleEdit(model)}/>
       </div>
     );
   }


### PR DESCRIPTION
The specialized handling here is leftover and unnecessary.  The Details.tsx component takes care of updating the title in the resource - which is automatically broadcast to the reducer by the EditorManager.  I tested and this fixes the problem and allows renaming of Orgs to be visible in the listing of all Orgs. 