### PR TITLE
restore code

### DIFF
--- a/src/data/content/common/clone.ts
+++ b/src/data/content/common/clone.ts
@@ -42,6 +42,8 @@ function changeForBlock(contentState: ContentState, block) : ContentState {
         copy[key] = data[key];
       }
 
+      const updatedState = contentState.createEntity(
+        entity.type, entity.mutability, copy);
       const createdKey = contentState.getLastCreatedEntityKey();
       const range = new SelectionState({
         anchorKey: block.key,
@@ -49,7 +51,7 @@ function changeForBlock(contentState: ContentState, block) : ContentState {
         anchorOffset: 0,
         focusOffset: 1,
       });
-      return Modifier.applyEntity(contentState, range, createdKey);
+      return Modifier.applyEntity(updatedState, range, createdKey);
     }
     return contentState;
 

--- a/src/data/content/html/todraft.ts
+++ b/src/data/content/html/todraft.ts
@@ -829,6 +829,13 @@ function material(item: Object, context: ParsingContext) {
 }
 
 function title(item: Object, context: ParsingContext) {
+
+  // Create the beginning block
+  const beginData : common.TitleBegin = {
+    type: 'title_begin',
+  };
+  addAtomicBlock(common.EntityTypes.title_begin, beginData, context);
+
   // Handle the children
   const children = getChildren(item);
   children.forEach(subItem => parse(subItem, context));


### PR DESCRIPTION
Restore code that was deleted as part of the automatic, unused variable cleanup.

1. todraft.ts - In this instance an unused variable 'beginBlock' was removed, but along with it the actual code that creates the beginning block (the call to 'addAtomicBlock', which adds the newly created block to the context argument).  I've restored that code but left out the unused beginBlock variable.  Because this code was removed, sections, pullouts, and examples that had titles would have imbalanced title sentinels added to the draft model - which ultimately, upon serialization back for saving, would cause a truncation of the page and loss of data.   I've tested locally and this fixes the problem of truncation that I saw in the BYU course.

2. clone.ts - The unused 'updatedState' variable was removed, along with it the call to createEntity.  This really wasn't the actual problem here. Instead, updatedState was supposed to be used on line 54.  