### PR TITLE
Authoring 899 empty contents

### DIFF
--- a/src/components/toolbar/InsertToolbar.tsx
+++ b/src/components/toolbar/InsertToolbar.tsx
@@ -65,9 +65,9 @@ export const InsertToolbar = injectSheetSFC<InsertToolbarProps>(styles)(({
     <React.Fragment>
       <ToolbarLayout.Inline>
         <ToolbarButton
-            onClick={() => console.log('NOT IMPLEMENTED')}
+            onClick={() => onInsert(new contentTypes.ContiguousText())}
             tooltip="Insert Text Block"
-            disabled>
+            disabled={!parentSupportsElementType('p')}>
           <i className="unicode-icon">T</i>
         </ToolbarButton>
         <ToolbarButton

--- a/src/data/content/common/elements.ts
+++ b/src/data/content/common/elements.ts
@@ -17,7 +17,7 @@ export const TEXT_ELEMENTS = ['#text', 'em', 'sub', 'sup', 'ipa', 'foreign',
   'term', 'var'];
 
 export const INLINE_ELEMENTS = [...ELEMENTS_LINK, ...ELEMENTS_MIXED, ...ELEMENTS_BLOCK,
-  ...ELEMENTS_MEDIA, ...ELEMENTS_LIST, ...TEXT_ELEMENTS, 'm:math'];
+  ...ELEMENTS_MEDIA, ...ELEMENTS_LIST, ...TEXT_ELEMENTS, 'm:math', 'p'];
 export const FLOW_ELEMENTS = [...INLINE_ELEMENTS];
 export const LINK_ELEMENTS = [...TEXT_ELEMENTS, ...ELEMENTS_LINK, 'image'];
 export const MATERIAL_ELEMENTS = [...INLINE_ELEMENTS];

--- a/src/data/content/learning/contiguous.ts
+++ b/src/data/content/learning/contiguous.ts
@@ -267,6 +267,24 @@ export class ContiguousText extends Immutable.Record(defaultContent) {
       })];
   }
 
+  // Returns true if the contiguous text contains one block and
+  // the text in that block is empty or contains all spaces
+  isEffectivelyEmpty() : boolean {
+    return this.content.getBlockMap().size === 1
+      && this.content.getFirstBlock().text.trim() === '';
+  }
+
+  // Returns true if the selection is collapsed and the cursor is
+  // positioned in the last block and no text other than spaces
+  // follows the cursor
+  isCursorAtEffectiveEnd(textSelection: TextSelection) : boolean {
+    const last = this.content.getLastBlock();
+    return textSelection.isCollapsed()
+      && last.key === textSelection.getAnchorKey()
+      && (last.text.length <= textSelection.getAnchorOffset()
+      || (last.text as string).substr(textSelection.getAnchorOffset()).trim() === '');
+  }
+
   tagInputRefsWithType(byId: Object) {
 
     const content = getEntities(EntityTypes.input_ref, this.content)

--- a/src/data/content/workbook/section.ts
+++ b/src/data/content/workbook/section.ts
@@ -20,9 +20,9 @@ export type SectionParams = {
 
 const defaultContent = {
   id: Maybe.nothing(),
-  title: Title.fromText('Title'),
+  title: Title.fromText('New Section Title'),
   purpose: Maybe.nothing(),
-  body: ContentElements.fromText('Content', '', WB_BODY_EXTENSIONS),
+  body: ContentElements.fromText('', '', [...BODY_ELEMENTS, ...WB_BODY_EXTENSIONS]),
   guid: '',
   contentType: 'Section',
 };
@@ -87,7 +87,7 @@ export class Section extends Immutable.Record(defaultContent) {
       section: {
         '#array': [
           this.title.toPersistence(),
-          { 
+          {
             body: {
               '#array': this.body.toPersistence(),
             },

--- a/src/editors/content/container/ContentContainer.tsx
+++ b/src/editors/content/container/ContentContainer.tsx
@@ -8,6 +8,7 @@ import { ContiguousText } from 'data/content/learning/contiguous';
 import { ContentElement } from 'data/content/common/interfaces';
 import { Maybe } from 'tsmonad';
 import { TextSelection } from 'types/active';
+import guid from 'utils/guid';
 
 import './ContentContainer.scss';
 
@@ -22,6 +23,18 @@ export interface ContentContainerState {
 
 }
 
+function indexOf(guid: string, model: ContentElements) : number {
+  let index = -1;
+  const arr = model.content.toArray();
+  for (let i = 0; i < arr.length; i += 1) {
+    if (arr[i].guid === guid) {
+      index = i;
+      break;
+    }
+  }
+  return index;
+}
+
 /**
  * The content container editor.
  */
@@ -31,6 +44,7 @@ export class ContentContainer
 
   textSelections: Immutable.Map<string, any>;
   supportedElements: Immutable.List<string>;
+  placeholder: Immutable.OrderedMap<string, ContentElement>;
 
   constructor(props) {
     super(props);
@@ -39,6 +53,9 @@ export class ContentContainer
 
     this.supportedElements = this.props.model.supportedElements;
     this.textSelections = Immutable.Map<string, any>();
+    const placeholderText = ContiguousText.fromText('', guid());
+    this.placeholder = Immutable.OrderedMap<string, ContentElement>()
+      .set(placeholderText.guid, placeholderText);
   }
 
   onEdit(childModel) {
@@ -50,7 +67,7 @@ export class ContentContainer
       .map((v, k) => [k, v])
       .toArray();
 
-    arr.splice(index, 0, [toInsert.guid, toInsert]);
+    arr.splice(index + 1, 0, [toInsert.guid, toInsert]);
 
     return model.with({ content: Immutable.OrderedMap<string, ContentElement>(arr) });
   }
@@ -58,45 +75,61 @@ export class ContentContainer
   onAddNew(toAdd, textSelection: Maybe<TextSelection>) {
     const { onEdit, model, activeContentGuid } = this.props;
 
-    const selection = textSelection.caseOf({ just: s => s, nothing: () => null });
+    // The following defines the insertion logic
 
     if (model.content.has(activeContentGuid)) {
 
-      let index = -1;
-      const arr = model.content.toArray();
-      for (let i = 0; i < arr.length; i += 1) {
-        if (arr[i].guid === activeContentGuid) {
-          index = i;
-          break;
-        }
-      }
+      const index = indexOf(activeContentGuid, model);
       const active = model.content.get(activeContentGuid);
+
       if (active instanceof ContiguousText) {
 
-        const pair = active.split(selection);
-        let updated = model.with({ content: model.content.set(pair[0].guid, pair[0]) });
-        updated = this.insertAfter(updated, toAdd, index + 1);
-        updated = this.insertAfter(updated, pair[1], index + 2);
-        onEdit(updated, toAdd);
+        const selection = textSelection.caseOf({
+          just: s => s,
+          nothing: () => TextSelection.createEmpty(active.content.getFirstBlock().key),
+        });
+
+        // We replace the text when it is effectively empty
+        if (active.isEffectivelyEmpty()) {
+          const updated : ContentElements = this.insertAfter(model, toAdd, index);
+          onEdit(updated.with({ content: updated.content.delete(activeContentGuid) }), toAdd);
+
+        // We insert after when the cursor is at the end
+        } else if (active.isCursorAtEffectiveEnd(selection)) {
+          onEdit(this.insertAfter(model, toAdd, index), toAdd);
+
+        // Otherwise we split the contiguous block in two parts and insert in between
+        } else {
+          const pair = active.split(selection);
+          let updated = model.with({ content: model.content.set(pair[0].guid, pair[0]) });
+          updated = this.insertAfter(updated, toAdd, index);
+          updated = this.insertAfter(updated, pair[1], index + 1);
+          onEdit(updated, toAdd);
+        }
 
       } else {
         onEdit(this.insertAfter(model, toAdd, index), toAdd);
       }
 
     } else {
+      // If somehow the active selected item isn't in this ContentElements, we
+      // still want to support addition of the new element.  Just insert it at the end
       onEdit(model.with({ content: model.content.set(toAdd.guid, toAdd) }), toAdd);
     }
 
   }
 
   onChildEdit(childModel, sourceObject) {
+    // When childModel is the placeholder, it will simply be added to the model
     const { onEdit, model } = this.props;
     onEdit(model.with({ content: model.content.set(childModel.guid, childModel) }), sourceObject);
   }
 
   onRemove(childModel) {
     const { onEdit, model } = this.props;
-    onEdit(model.with({ content: model.content.delete(childModel.guid) }), childModel);
+    if (model.content.has(childModel.guid)) {
+      onEdit(model.with({ content: model.content.delete(childModel.guid) }), childModel);
+    }
   }
 
   renderSidebar() {
@@ -110,7 +143,13 @@ export class ContentContainer
   renderMain() : JSX.Element {
     const { hideContentLabel, hover, onUpdateHover } = this.props;
 
-    const editors = this.props.model.content
+    // We want this component to display a ContiguousTextEditor in the
+    // case where there is no content at all in the model
+    const contentOrPlaceholder = this.props.model.content.size === 0
+      ? this.placeholder
+      : this.props.model.content;
+
+    const editors = contentOrPlaceholder
       .toArray()
       .map((model) => {
         const props = {

--- a/src/editors/content/learning/ContiguousTextToolbar.controller.ts
+++ b/src/editors/content/learning/ContiguousTextToolbar.controller.ts
@@ -23,7 +23,10 @@ const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
   const { activeContext } = state;
 
   return {
-    selection: activeContext.textSelection.caseOf({ just: s => s, nothing: () => null }),
+    selection: activeContext.textSelection.caseOf({ just: s => s, nothing: () => {
+      return TextSelection.createEmpty('');
+    },
+    }),
   };
 };
 

--- a/src/editors/content/learning/Example.tsx
+++ b/src/editors/content/learning/Example.tsx
@@ -10,6 +10,8 @@ import { ToolbarButton, ToolbarButtonSize } from 'components/toolbar/ToolbarButt
 import ContiguousTextEditor from 'editors/content/learning/ContiguousTextEditor.tsx';
 import { CONTENT_COLORS } from 'editors/content/utils/content';
 
+import './nested.scss';
+
 export interface ExampleProps extends AbstractContentEditorProps<ExampleType> {
   onShowSidebar: () => void;
 }
@@ -66,18 +68,20 @@ export class Example extends AbstractContentEditor<ExampleType, ExampleProps, Ex
 
   renderMain(): JSX.Element {
     return (
-      <div className="exampleEditor">
+      <div>
         <ContiguousTextEditor
           {...this.props}
           model={(this.props.model.title.text.content as any).first()}
           editorStyles={{ fontSize: 20 }}
           viewOnly
           onEdit={() => {}} />
-        <ContentContainer
-          {...this.props}
-          model={this.props.model.content}
-          onEdit={this.onContentEdit}
-        />
+        <div className="nested-container">
+          <ContentContainer
+            {...this.props}
+            model={this.props.model.content}
+            onEdit={this.onContentEdit}
+          />
+        </div>
       </div>
     );
   }

--- a/src/editors/content/learning/Pullout.tsx
+++ b/src/editors/content/learning/Pullout.tsx
@@ -14,6 +14,8 @@ import { ToolbarButton, ToolbarButtonSize } from 'components/toolbar/ToolbarButt
 import ContiguousTextEditor from 'editors/content/learning/ContiguousTextEditor.tsx';
 import { CONTENT_COLORS } from 'editors/content/utils/content';
 
+import './nested.scss';
+
 export interface PulloutProps extends AbstractContentEditorProps<PulloutType> {
   onShowSidebar: () => void;
 }
@@ -119,18 +121,20 @@ export class Pullout extends AbstractContentEditor<PulloutType, PulloutProps, Pu
 
   renderMain(): JSX.Element {
     return (
-    <div className="pulloutEditor">
+    <div>
       <ContiguousTextEditor
         {...this.props}
         model={(this.props.model.title.text.content as any).first()}
         editorStyles={{ fontSize: 20 }}
         viewOnly
         onEdit={() => {}} />
-      <ContentContainer
-        {...this.props}
-        model={this.props.model.content}
-        onEdit={this.onContentEdit}
-      />
+      <div className="nested-container">
+        <ContentContainer
+          {...this.props}
+          model={this.props.model.content}
+          onEdit={this.onContentEdit}
+        />
+      </div>
     </div>
     );
   }

--- a/src/editors/content/learning/Section.tsx
+++ b/src/editors/content/learning/Section.tsx
@@ -13,6 +13,8 @@ import { ToolbarButton, ToolbarButtonSize } from 'components/toolbar/ToolbarButt
 import ContiguousTextEditor from 'editors/content/learning/ContiguousTextEditor.tsx';
 import { CONTENT_COLORS } from 'editors/content/utils/content';
 
+import './nested.scss';
+
 export interface SectionProps extends AbstractContentEditorProps<SectionType> {
   onShowSidebar: () => void;
 }
@@ -101,18 +103,20 @@ export class Section extends AbstractContentEditor<SectionType, SectionProps, Se
 
   renderMain(): JSX.Element {
     return (
-    <div className="pulloutEditor">
+    <div>
       <ContiguousTextEditor
         {...this.props}
         model={(this.props.model.title.text.content as any).first()}
         editorStyles={{ fontSize: 20 }}
         viewOnly
         onEdit={() => {}} />
-      <ContentContainer
-        {...this.props}
-        model={this.props.model.body}
-        onEdit={this.onBodyEdit}
-      />
+      <div className="nested-container">
+        <ContentContainer
+          {...this.props}
+          model={this.props.model.body}
+          onEdit={this.onBodyEdit}
+        />
+      </div>
     </div>
     );
   }

--- a/src/editors/content/learning/nested.scss
+++ b/src/editors/content/learning/nested.scss
@@ -1,0 +1,3 @@
+.nested-container {
+  margin-left: 20px;
+}

--- a/src/editors/content/media/ImageEditor.tsx
+++ b/src/editors/content/media/ImageEditor.tsx
@@ -150,9 +150,9 @@ export class ImageEditor
     this.props.onEdit(this.props.model.with({ titleContent }));
   }
 
-  onCaptionEdit(content: ContentElements) {
+  onCaptionEdit(content: ContentElements, src) {
     const caption = this.props.model.caption.with({ content });
-    this.props.onEdit(this.props.model.with({ caption }));
+    this.props.onEdit(this.props.model.with({ caption }), src);
   }
 
   onSetClick() {
@@ -299,7 +299,10 @@ export class ImageEditor
       });
   }
 
+
+
   renderSidebar() {
+
     return (
       <SidebarContent title="Image">
         <SidebarGroup label="Media">


### PR DESCRIPTION
-Adjusts the insertion policy to replace empty text, and not split text blocks when cursor is at end
-Fixes ContentContainer to render a placeholder text editor when contents is empty.  I tested this with Image captions and it works, but persistence of image captions is broken.  I left out that UI since Zach is about to add it back it
-Also fixes a problem with how section body is defined as I could not insert images (or anything else) into them
-Applies some indenting to sections, pullouts and examples