### PR TITLE
add ability to select content elements in assessment and pool editors

### DIFF
--- a/src/components/sidebar/ContextAwareSidebar.tsx
+++ b/src/components/sidebar/ContextAwareSidebar.tsx
@@ -147,6 +147,8 @@ export class ContextAwareSidebar
         context: contentParent.props.context,
         services: contentParent.props.services,
         editMode: contentParent.props.editMode,
+        hover: null,
+        onUpdateHover: () => {},
       };
 
       contentRenderer = React.createElement(

--- a/src/data/activity_templates.ts
+++ b/src/data/activity_templates.ts
@@ -68,10 +68,10 @@ export function assessmentTemplate(title: string) {
                         '@match': 'yes',
                         '@score': '0',
                         feedback: {
-                          '#text': 'Incorrect; using another student?s password is not acceptable, '
-                          + 'even if it?s left out in the open. Further, Albert has assumed his '
-                          + 'girlfriend\'s identity by using her account, which is also a '
-                          + 'violation of the Computing Policy.',
+                          '#text': 'Incorrect; using another student\'s password is not '
+                          + 'acceptable, even if it\'s left out in the open. Further, '
+                          + 'Albert has assumed his girlfriend\'s identity by using her '
+                          + 'account, which is also a violation of the Computing Policy.',
                         },
                       },
                     },
@@ -81,7 +81,7 @@ export function assessmentTemplate(title: string) {
                         '@score': '1',
                         feedback: {
                           '#text': 'Correct; this is a pretty clear violation of the policy, '
-                          + 'including using another person?s account and impersonating another '
+                          + 'including using another person\'s account and impersonating another '
                           + 'individual.',
                         },
                       },

--- a/src/editors/content/common/AbstractContentEditor.tsx
+++ b/src/editors/content/common/AbstractContentEditor.tsx
@@ -16,7 +16,6 @@ export enum RenderContext {
 export interface AbstractContentEditorProps<ModelType> {
   model: ModelType;
   parent?: ParentContainer;
-  activeContentGuid?: string;
   onEdit: (updated: ModelType, source?: Object) => void;
   onFocus: (
     model: any, parent: ParentContainer,
@@ -26,6 +25,9 @@ export interface AbstractContentEditorProps<ModelType> {
   editMode: boolean;
   renderContext?: RenderContext;
   styles?: any;
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface AbstractContentEditorState {}

--- a/src/editors/content/common/AbstractItemPartEditor.tsx
+++ b/src/editors/content/common/AbstractItemPartEditor.tsx
@@ -29,6 +29,9 @@ export interface AbstractItemPartEditorProps<ItemType> {
 
   onRemove: (item: ItemType, part: contentTypes.Part) => void;
 
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface AbstractItemPartEditorState {
@@ -50,7 +53,9 @@ export abstract class
 
   shouldComponentUpdate(nextProps, nextState) {
     return this.props.partModel !== nextProps.partModel
-      || this.props.itemModel !== nextProps.itemModel;
+      || this.props.itemModel !== nextProps.itemModel
+      || this.props.hover !== nextProps.hover
+      || this.props.activeContentGuid !== nextProps.activeContentGuid;
   }
 
 }

--- a/src/editors/content/common/Choice.tsx
+++ b/src/editors/content/common/Choice.tsx
@@ -78,6 +78,9 @@ export interface ChoiceProps  {
   onEditFeedback?: (response: contentTypes.Response, feedback: contentTypes.Feedback, src) => void;
   onEditScore?: (response: contentTypes.Response, score: string) => void;
   onRemove: (choiceId: string) => void;
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface ChoiceState {
@@ -108,6 +111,9 @@ export class Choice extends React.PureComponent<ChoiceProps, ChoiceState> {
 
       feedbackEditor =
         <ContentContainer
+          activeContentGuid={this.props.activeContentGuid}
+          hover={this.props.hover}
+          onUpdateHover={this.props.onUpdateHover}
           onFocus={this.props.onFocus}
           model={feedback.body}
           editMode={editMode}
@@ -135,6 +141,9 @@ export class Choice extends React.PureComponent<ChoiceProps, ChoiceState> {
       <InputListItem
         className="choice"
         id={choice.guid}
+        activeContentGuid={this.props.activeContentGuid}
+        hover={this.props.hover}
+        onUpdateHover={this.props.onUpdateHover}
         onFocus={this.props.onFocus}
         label={convert.toAlphaNotation(index)}
         context={context}

--- a/src/editors/content/common/InputList.scss
+++ b/src/editors/content/common/InputList.scss
@@ -45,6 +45,7 @@
       display: block;
       position: relative;
       border: solid 2px transparent;
+      padding-left: 15px;
 
       &.drop-hover {
         border: dashed 2px #f4bf42;

--- a/src/editors/content/common/InputList.tsx
+++ b/src/editors/content/common/InputList.tsx
@@ -51,6 +51,10 @@ export interface InputListItemProps {
   connectDropTarget?: any;
   isHovered?: boolean;
   canDrop?: boolean;
+
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 const source = {
@@ -139,6 +143,9 @@ export class InputListItem extends React.PureComponent<InputListItemProps> {
                 : (null)
               }
               <ContentContainer
+                activeContentGuid={this.props.activeContentGuid}
+                hover={this.props.hover}
+                onUpdateHover={this.props.onUpdateHover}
                 onFocus={this.props.onFocus}
                 context={context}
                 services={services}

--- a/src/editors/content/common/RichTextEditor.tsx
+++ b/src/editors/content/common/RichTextEditor.tsx
@@ -43,6 +43,9 @@ export class RichTextEditor
   renderMain() : JSX.Element {
 
     const editor = <ContiguousTextEditor
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             onFocus={this.props.onFocus}
             context={this.props.context}
             services={this.props.services}

--- a/src/editors/content/container/ContentContainer.tsx
+++ b/src/editors/content/container/ContentContainer.tsx
@@ -15,8 +15,7 @@ import './ContentContainer.scss';
 export interface ContentContainerProps
     extends AbstractContentEditorProps<ContentElements> {
   hideContentLabel?: boolean;
-  hover?: string;
-  onUpdateHover?: (hover: string) => void;
+  activeContentGuid: string;
 }
 
 export interface ContentContainerState {
@@ -237,7 +236,7 @@ export class ContentContainer
           <ContentDecorator
             contentType={model.contentType}
             onSelect={() => this.onSelect(model)}
-            hideContentLabel={hideContentLabel}
+            hideContentLabel={hideContentLabel || !hover}
             key={model.guid}
             onMouseOver={() => onUpdateHover && onUpdateHover(model.guid) }
             isHoveringContent={hover === model.guid}

--- a/src/editors/content/container/ContentDecorator.style.ts
+++ b/src/editors/content/container/ContentDecorator.style.ts
@@ -17,6 +17,7 @@ export default {
       // display: 'flex',
       left: -18,
       opacity: 1,
+      cursor: 'grab',
       borderLeft: props => '2px solid ' + getContentColor(props.contentType),
 
       transition: 'opacity .1s ease-in',
@@ -30,7 +31,6 @@ export default {
     left: -14,
     width: 18,
     height: '100%',
-    cursor: 'grab',
     flexDirection: 'column',
     color: 'rgba(0,0,0,.2)',
     borderLeft: '2px solid transparent',
@@ -62,6 +62,11 @@ export default {
       '& $label': {
         marginLeft: 2,
       },
+
+      '& .contiguousTextEditor': {
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+      },
     },
   },
   label: {
@@ -84,5 +89,10 @@ export default {
   },
   content: {
     flex: 1,
+
+    '&.active-content .contiguousTextEditor': {
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    },
   },
 };

--- a/src/editors/content/container/ContentDecorator.tsx
+++ b/src/editors/content/container/ContentDecorator.tsx
@@ -42,19 +42,26 @@ export class ContentDecorator
         isHoveringContent && classes.hover,
       ])}
       onMouseOver={(e) => { onMouseOver(); e.stopPropagation(); }}>
-        {!hideContentLabel &&
-          <div className={classNames([
-            classes.handle,
-            isActiveContent && 'active-content',
-          ])}
-            onMouseDown={onSelect}>
-            <div className={classes.label}>
-              {getContentIcon(contentType)}
+        {hideContentLabel
+          ? null
+          : (
+            <div
+              className={classNames([
+                classes.handle,
+                isActiveContent && 'active-content',
+              ])}
+              onMouseDown={onSelect}>
+              <div className={classes.label}>
+                {getContentIcon(contentType)}
+              </div>
+              <div className={classes.grip} />
             </div>
-            <div className={classes.grip} />
-          </div>
+          )
         }
-        <div className={classes.content}>
+        <div className={classNames([
+          classes.content,
+          isActiveContent && 'active-content',
+        ])}>
         {children}
         </div>
       </div>

--- a/src/editors/content/content/ContentEditor.scss
+++ b/src/editors/content/content/ContentEditor.scss
@@ -2,7 +2,7 @@
 @import 'oli/mixins';
 
 .content-editor {
-  padding: 0 20px;
+  padding: 0 30px;
 
   .content-options {
     display: flex;

--- a/src/editors/content/content/ContentEditor.tsx
+++ b/src/editors/content/content/ContentEditor.tsx
@@ -13,6 +13,9 @@ type IdTypes = {
 
 export interface ContentEditorProps extends AbstractContentEditorProps<contentTypes.Content> {
   onRemove: (guid: string) => void;
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface ContentEditorState {

--- a/src/editors/content/items/FillInTheBlank.tsx
+++ b/src/editors/content/items/FillInTheBlank.tsx
@@ -187,6 +187,9 @@ FillInTheBlank
       const response = responses[i];
       return (
         <Choice
+          activeContentGuid={this.props.activeContentGuid}
+          hover={this.props.hover}
+          onUpdateHover={this.props.onUpdateHover}
           onFocus={this.props.onFocus}
           key={choice.guid}
           index={i}

--- a/src/editors/content/learning/Audio.tsx
+++ b/src/editors/content/learning/Audio.tsx
@@ -52,6 +52,9 @@ class Audio extends InteractiveRenderer<AudioProps, AudioState> {
         }
       }>
         <AudioEditor
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={null}
           model={this.props.data.audio}
           context={b.context}

--- a/src/editors/content/learning/Example.tsx
+++ b/src/editors/content/learning/Example.tsx
@@ -46,6 +46,9 @@ export class Example extends AbstractContentEditor<ExampleType, ExampleProps, Ex
         <SidebarGroup label="Title">
           <ToolbarContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             model={model.title.text}
             onEdit={text => this.onTitleEdit(model.title.with({ text }), model)} />
         </SidebarGroup>
@@ -78,6 +81,9 @@ export class Example extends AbstractContentEditor<ExampleType, ExampleProps, Ex
         <div className="nested-container">
           <ContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             model={this.props.model.content}
             onEdit={this.onContentEdit}
           />

--- a/src/editors/content/learning/IFrame.tsx
+++ b/src/editors/content/learning/IFrame.tsx
@@ -52,6 +52,9 @@ class IFrame extends InteractiveRenderer<IFrameProps, IFrameState> {
         }
       }>
         <IFrameEditor
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={null}
           model={this.props.data.iframe}
           context={b.context}

--- a/src/editors/content/learning/Pullout.tsx
+++ b/src/editors/content/learning/Pullout.tsx
@@ -74,6 +74,9 @@ export class Pullout extends AbstractContentEditor<PulloutType, PulloutProps, Pu
         <SidebarGroup label="Title">
           <ToolbarContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             model={model.title.text}
             onEdit={text => this.onTitleEdit(model.title.with({ text }), model)} />
         </SidebarGroup>

--- a/src/editors/content/learning/Section.tsx
+++ b/src/editors/content/learning/Section.tsx
@@ -59,6 +59,9 @@ export class Section extends AbstractContentEditor<SectionType, SectionProps, Se
         <SidebarGroup label="Title">
           <ToolbarContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             model={model.title.text}
             onEdit={text => this.onTitleEdit(model.title.with({ text }), model)} />
         </SidebarGroup>
@@ -112,6 +115,9 @@ export class Section extends AbstractContentEditor<SectionType, SectionProps, Se
         onEdit={() => {}} />
       <div className="nested-container">
         <ContentContainer
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           {...this.props}
           model={this.props.model.body}
           onEdit={this.onBodyEdit}

--- a/src/editors/content/learning/Video.tsx
+++ b/src/editors/content/learning/Video.tsx
@@ -52,6 +52,9 @@ class Video extends InteractiveRenderer<VideoProps, VideoState> {
         }
       }>
         <VideoEditor
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={null}
           model={this.props.data.video}
           context={b.context}

--- a/src/editors/content/media/ImageEditor.tsx
+++ b/src/editors/content/media/ImageEditor.tsx
@@ -264,6 +264,9 @@ export class ImageEditor
 
           {this.row('Title', '8', <ContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             model={titleContent.text}
             editMode={this.props.editMode}
             onEdit={this.onTitleEdit}
@@ -271,6 +274,9 @@ export class ImageEditor
 
           {this.row('Caption', '8', <ContentContainer
           {...this.props}
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           model={caption.content}
           editMode={this.props.editMode}
           onEdit={this.onCaptionEdit}

--- a/src/editors/content/part/ChoiceFeedback.tsx
+++ b/src/editors/content/part/ChoiceFeedback.tsx
@@ -201,6 +201,9 @@ export abstract class ChoiceFeedback
       // finally, render all response elements and the psudo-feedback element for all other choices
       .map((response, i) => (
         <InputListItem
+          activeContentGuid={this.props.activeContentGuid}
+          hover={this.props.hover}
+          onUpdateHover={this.props.onUpdateHover}
           onFocus={this.props.onFocus}
           key={response.guid}
           className="response"

--- a/src/editors/content/part/Feedback.tsx
+++ b/src/editors/content/part/Feedback.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as Immutable from 'immutable';
 import * as contentTypes from '../../../data/contentTypes';
 import { AbstractContentEditor, AbstractContentEditorProps } from '../common/AbstractContentEditor';
 import {
@@ -100,13 +101,22 @@ export abstract class Feedback
     return model.responses.toArray()
       // if a default response doesnt exist, create one and append it to the list
       .concat(this.getDefaultResponse() ? [] : new contentTypes.Response({
-        match : '*',
+        match: '*',
+        feedback: Immutable.OrderedMap((() => {
+          const newGuid = guid();
+          return ({
+            [newGuid]: contentTypes.Feedback.fromText('', newGuid),
+          });
+        })()),
       }))
       .map((response, i) => {
         const isDefault = response.match === '*';
 
         return (
           <InputListItem
+            activeContentGuid={this.props.activeContentGuid}
+            hover={this.props.hover}
+            onUpdateHover={this.props.onUpdateHover}
             onFocus={this.props.onFocus}
             key={response.guid}
             className="response"

--- a/src/editors/content/part/Hints.tsx
+++ b/src/editors/content/part/Hints.tsx
@@ -47,6 +47,9 @@ export abstract class Hints
     return this.props.model.hints.toArray().map((i) => {
       return (
         <HintEditor
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={this.props.onFocus}
           key={i.guid}
           {...this.props}

--- a/src/editors/content/question/CheckAllThatApply.tsx
+++ b/src/editors/content/question/CheckAllThatApply.tsx
@@ -353,6 +353,9 @@ export class CheckAllThatApply extends Question<CheckAllThatApplyProps, CheckAll
       .map((choice, index) => {
         return (
           <Choice
+            activeContentGuid={this.props.activeContentGuid}
+            hover={this.props.hover}
+            onUpdateHover={this.props.onUpdateHover}
             onFocus={this.props.onFocus}
             key={choice.guid}
             index={index}

--- a/src/editors/content/question/CriteriaEditor.tsx
+++ b/src/editors/content/question/CriteriaEditor.tsx
@@ -78,6 +78,9 @@ export class CriteriaEditor
         {controls}
 
         <ContentContainer
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={this.props.onFocus}
           services={this.props.services}
           context={this.props.context}

--- a/src/editors/content/question/MultipartInput.controller.ts
+++ b/src/editors/content/question/MultipartInput.controller.ts
@@ -15,6 +15,7 @@ interface DispatchProps {
 
 interface OwnProps extends QuestionProps<contentTypes.QuestionItem> {
   canInsertAnotherPart: PartAddPredicate;
+  onAddItemPart: (item, part, body) => void;
 }
 
 const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {

--- a/src/editors/content/question/MultipartInput.tsx
+++ b/src/editors/content/question/MultipartInput.tsx
@@ -21,6 +21,7 @@ export interface MultipartInputProps
   extends QuestionProps<contentTypes.QuestionItem> {
   activeContext: ActiveContext;
   canInsertAnotherPart: PartAddPredicate;
+  onAddItemPart: (item, part, body) => void;
 }
 
 export interface MultipartInputState extends QuestionState {
@@ -160,6 +161,9 @@ export class MultipartInput extends Question<MultipartInputProps, MultipartInput
 
         </div>
         <ContentContainer
+          activeContentGuid={this.props.activeContentGuid}
+          hover={this.props.hover}
+          onUpdateHover={this.props.onUpdateHover}
           onFocus={this.props.onFocus}
           editMode={editMode}
           services={services}
@@ -195,6 +199,9 @@ export class MultipartInput extends Question<MultipartInputProps, MultipartInput
         case 'FillInTheBlank':
           return (
             <FillInTheBlank
+              activeContentGuid={this.props.activeContentGuid}
+              hover={this.props.hover}
+              onUpdateHover={this.props.onUpdateHover}
               context={props.context}
               services={props.services}
               editMode={props.editMode}
@@ -209,6 +216,9 @@ export class MultipartInput extends Question<MultipartInputProps, MultipartInput
         case 'Numeric':
           return (
             <Numeric
+              activeContentGuid={this.props.activeContentGuid}
+              hover={this.props.hover}
+              onUpdateHover={this.props.onUpdateHover}
               context={props.context}
               services={props.services}
               editMode={props.editMode}
@@ -223,6 +233,9 @@ export class MultipartInput extends Question<MultipartInputProps, MultipartInput
         case 'Text':
           return (
             <Text
+              activeContentGuid={this.props.activeContentGuid}
+              hover={this.props.hover}
+              onUpdateHover={this.props.onUpdateHover}
               context={props.context}
               services={props.services}
               editMode={props.editMode}

--- a/src/editors/content/question/MultipleChoice.tsx
+++ b/src/editors/content/question/MultipleChoice.tsx
@@ -252,6 +252,9 @@ export class MultipleChoice
       const response = responses[i];
       return (
         <Choice
+          activeContentGuid={this.props.activeContentGuid}
+          hover={this.props.hover}
+          onUpdateHover={this.props.onUpdateHover}
           onFocus={this.props.onFocus}
           key={choice.guid}
           index={i}

--- a/src/editors/content/question/Ordering.tsx
+++ b/src/editors/content/question/Ordering.tsx
@@ -154,6 +154,9 @@ export class Ordering extends Question<OrderingProps, OrderingState> {
       .map((choice, index) => {
         return (
           <Choice
+            activeContentGuid={this.props.activeContentGuid}
+            hover={this.props.hover}
+            onUpdateHover={this.props.onUpdateHover}
             onFocus={this.props.onFocus}
             key={choice.guid}
             index={index}

--- a/src/editors/content/question/Question.tsx
+++ b/src/editors/content/question/Question.tsx
@@ -25,7 +25,6 @@ export interface QuestionProps<ModelType>
   onBodyEdit: (...args: any[]) => any;
   onFocus: (child, model, textSelection) => void;
   onItemFocus: (itemId: string) => void;
-  onAddItemPart?: (item, part, body) => void;
   body: any;
   grading: any;
   onGradingChange: (value) => void;
@@ -34,6 +33,9 @@ export interface QuestionProps<ModelType>
   model: contentTypes.Question;
   canRemoveQuestion: boolean;
   onRemoveQuestion: () => void;
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface QuestionState {
@@ -197,6 +199,9 @@ export abstract class Question<P extends QuestionProps<contentTypes.QuestionItem
     return (
       <div className="question-body" key="question">
           <ContentContainer
+            activeContentGuid={this.props.activeContentGuid}
+            hover={this.props.hover}
+            onUpdateHover={this.props.onUpdateHover}
             onFocus={this.props.onFocus}
             editMode={editMode}
             services={services}
@@ -222,6 +227,9 @@ export abstract class Question<P extends QuestionProps<contentTypes.QuestionItem
           <TabSectionHeader title="Attached Skills"/>
           <TabSectionContent>
             <SkillsEditor
+              activeContentGuid={null}
+              hover={null}
+              onUpdateHover={() => {}}
               editMode={this.props.editMode}
               services={this.props.services}
               context={this.props.context}
@@ -259,6 +267,9 @@ export abstract class Question<P extends QuestionProps<contentTypes.QuestionItem
           {partModel.criteria.toArray()
             .map(c => (
               <CriteriaEditor
+                activeContentGuid={null}
+                hover={null}
+                onUpdateHover={() => {}}
                 onFocus={this.props.onItemFocus.bind(this, c, this)}
                 parent={null}
                 key={c.guid}

--- a/src/editors/content/question/QuestionEditor.scss
+++ b/src/editors/content/question/QuestionEditor.scss
@@ -2,7 +2,7 @@
 @import 'oli/mixins';
 
 .question-editor {
-  padding: 0 20px;
+  padding: 0 30px;
 
   .question-title {
     display: flex;

--- a/src/editors/content/question/QuestionEditor.tsx
+++ b/src/editors/content/question/QuestionEditor.tsx
@@ -21,6 +21,9 @@ export interface QuestionEditorProps extends AbstractContentEditorProps<contentT
   isParentAssessmentGraded?: boolean;
   allSkills: Immutable.OrderedMap<string, Skill>;
   canRemove: boolean;
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 export interface QuestionEditorState {
@@ -61,6 +64,7 @@ export class QuestionEditor
     this.onItemPartEdit = this.onItemPartEdit.bind(this);
     this.onRemove = this.onRemove.bind(this);
     this.onGradingChange = this.onGradingChange.bind(this);
+    this.onAddItemPart = this.onAddItemPart.bind(this);
 
     this.fillInTheBlankCommand
       = new InsertInputRefCommand(this, createFillInTheBlank, 'FillInTheBlank');
@@ -88,6 +92,14 @@ export class QuestionEditor
     }
 
     if (nextProps.activeItemId !== this.state.activeItemId) {
+      return true;
+    }
+
+    if (nextProps.hover !== this.props.hover) {
+      return true;
+    }
+
+    if (nextProps.activeContentGuid !== this.props.activeContentGuid) {
       return true;
     }
 
@@ -237,157 +249,54 @@ export class QuestionEditor
       || item.contentType === 'Numeric'
       || item.contentType === 'FillInTheBlank';
 
+    const questionProps = {
+      ...this.props,
+      onItemFocus: this.onFocusChange,
+      onRemove: this.onRemove,
+      onBlur: this.onBlur,
+      itemModel: item,
+      partModel: part,
+      body: this.props.model.body,
+      grading: this.props.model.grading,
+      onGradingChange: this.onGradingChange,
+      onBodyEdit: this.onBodyEdit,
+      hideGradingCriteria: !this.props.isParentAssessmentGraded,
+      canRemoveQuestion: canRemove,
+      onRemoveQuestion: this.props.onRemove.bind(this, this.props.model.guid),
+      onEdit: (c, p, src) => this.onItemPartEdit(c, p, src),
+    };
+
     if (isMultipart) {
-      const key = item ? item.guid : Math.random() + '';
       return (
         <MultipartInput
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={key}
-          itemModel={item}
-          partModel={part}
-          onAddItemPart={this.onAddItemPart.bind(this)}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
+          {...questionProps} itemModel={item}
           canInsertAnotherPart={part => this.canInsertAnotherPart(this.props.model, part)}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+          onAddItemPart={this.onAddItemPart}/>
       );
     }
     if (item.contentType === 'MultipleChoice' && item.select === 'single') {
       return (
-        <MultipleChoice
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={item.guid}
-          itemModel={item}
-          partModel={part}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+        <MultipleChoice {...questionProps} itemModel={item} />
       );
     }
     if (item.contentType === 'MultipleChoice' && item.select === 'multiple') {
       return (
-        <CheckAllThatApply
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={item.guid}
-          itemModel={item}
-          partModel={part}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+        <CheckAllThatApply {...questionProps} itemModel={item} />
       );
     }
     if (item.contentType === 'ShortAnswer') {
       return (
-        <ShortAnswer
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={item.guid}
-          itemModel={item}
-          partModel={part}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+        <ShortAnswer {...questionProps} itemModel={item} />
       );
     }
     if (item.contentType === 'Ordering') {
       return (
-        <Ordering
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={item.guid}
-          itemModel={item}
-          partModel={part}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+        <Ordering {...questionProps} itemModel={item} />
       );
     }
     if (item.contentType === 'Essay') {
       return (
-        <Essay
-          onFocus={this.props.onFocus}
-          onItemFocus={this.onFocusChange}
-          context={this.props.context}
-          services={this.props.services}
-          editMode={this.props.editMode}
-          onRemove={this.onRemove}
-          onBlur={this.onBlur}
-          allSkills={this.props.allSkills}
-          key={item.guid}
-          itemModel={item}
-          partModel={part}
-          body={this.props.model.body}
-          grading={this.props.model.grading}
-          onGradingChange={this.onGradingChange}
-          onBodyEdit={this.onBodyEdit}
-          hideGradingCriteria={!this.props.isParentAssessmentGraded}
-          model={this.props.model}
-          canRemoveQuestion={canRemove}
-          onRemoveQuestion={this.props.onRemove.bind(this, this.props.model.guid)}
-          onEdit={(c, p, src) => this.onItemPartEdit(c, p, src)} />
+        <Essay {...questionProps} itemModel={item} />
       );
     }
   }

--- a/src/editors/content/table/ModalTableEditor.tsx
+++ b/src/editors/content/table/ModalTableEditor.tsx
@@ -48,6 +48,9 @@ class ModalTableEditor extends React.PureComponent<ModalTableEditorProps, ModalT
         onInsert={() => this.props.onInsert(this.state.model)}>
 
         <TableEditor
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
           onFocus={null}
           context={this.props.context}
           services={this.props.services}

--- a/src/editors/content/title/TitleContentEditor.tsx
+++ b/src/editors/content/title/TitleContentEditor.tsx
@@ -33,6 +33,9 @@ export class TitleContentEditor
   renderMain() : JSX.Element {
     return <ContentContainer
       {...this.props}
+      activeContentGuid={null}
+      hover={null}
+      onUpdateHover={() => {}}
       model={this.props.model.text}
       onEdit={this.onTitleEdit.bind(this)}
     />;

--- a/src/editors/document/assessment/AssessmentEditor.controller.ts
+++ b/src/editors/document/assessment/AssessmentEditor.controller.ts
@@ -4,11 +4,13 @@ import { fetchSkills } from 'actions/skills';
 import { AbstractEditorProps } from '../common/AbstractEditor';
 import { AssessmentModel } from 'data/models';
 import * as activeActions from 'actions/active';
+import { updateHover } from 'actions/hover';
 import { ParentContainer, TextSelection } from 'types/active';
 import { Maybe } from 'tsmonad';
 
 interface StateProps {
-
+  activeContext: any;
+  hover: string;
 }
 
 interface DispatchProps {
@@ -17,15 +19,17 @@ interface DispatchProps {
   onUpdateContentSelection: (
     documentId: string, content: Object, container: ParentContainer,
     textSelection: Maybe<TextSelection>) => void;
+  onUpdateHover: (hover: string) => void;
 }
 
 interface OwnProps extends AbstractEditorProps<AssessmentModel> {}
 
 const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
-  const { activeContext } = state;
+  const { activeContext, hover } = state;
 
   return {
     activeContext,
+    hover,
   };
 };
 
@@ -42,6 +46,9 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
       parent: ParentContainer, textSelection: Maybe<TextSelection>) => {
 
       return dispatch(activeActions.updateContext(documentId, content, parent, textSelection));
+    },
+    onUpdateHover: (hover: string) => {
+      return dispatch(updateHover(hover));
     },
   };
 };

--- a/src/editors/document/assessment/AssessmentEditor.scss
+++ b/src/editors/document/assessment/AssessmentEditor.scss
@@ -22,6 +22,13 @@
       overflow: auto;
       padding: 0 10px 20px 10px;
 
+      .content-decorator {
+        margin-top: 20px;
+
+        &:first-child {
+          margin-top: 0;
+        }
+      }
     }
   }
 

--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -33,6 +33,8 @@ export interface AssessmentEditorProps extends AbstractEditorProps<models.Assess
   onUpdateContentSelection: (
     documentId: string, content: Object, container: ParentContainer,
     textSelection: Maybe<TextSelection>) => void;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 interface AssessmentEditorState extends AbstractEditorState {
@@ -86,6 +88,7 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
         || this.props.activeContext !== nextProps.activeContext
         || this.props.expanded !== nextProps.expanded
         || this.props.editMode !== nextProps.editMode
+        || this.props.hover !== nextProps.hover
         || this.state.currentPage !== nextState.currentPage
         || this.state.currentNode !== nextState.currentNode
         || this.state.undoStackSize !== nextState.undoStackSize
@@ -204,15 +207,19 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
 
 
   renderTitle() {
-    return <TitleContentEditor
-            parent={null}
-            onFocus={this.onFocus.bind(this, this.props.model.title, this)}
-            services={this.props.services}
-            context={this.props.context}
-            editMode={this.props.editMode}
-            model={this.props.model.title}
-            onEdit={this.onTitleEdit}
-            />;
+    return (
+      <TitleContentEditor
+        activeContentGuid={null}
+        hover={null}
+        onUpdateHover={() => {}}
+        parent={null}
+        onFocus={this.onFocus.bind(this, this.props.model.title, this)}
+        services={this.props.services}
+        context={this.props.context}
+        editMode={this.props.editMode}
+        model={this.props.model.title}
+        onEdit={this.onTitleEdit} />
+    );
   }
 
   onAddContent() {
@@ -477,12 +484,15 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
       nothing: () => '',
     });
 
-    const rendererProps = {
-      model: this.props.model,
+    const activeContentGuid = this.props.activeContext.activeChild.caseOf({
+      just: c => (c as any).guid,
+      nothing: () => '',
+    });
+
+    const assessmentNodeProps = {
+      ...this.props,
       skills: this.props.context.skills,
-      editMode: this.props.editMode,
-      context: this.props.context,
-      services: this.props.services,
+      activeContentGuid,
     };
 
     return (
@@ -507,7 +517,7 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
               </div>
               <div className="nodeContainer">
                 {renderAssessmentNode(
-                  this.state.currentNode, rendererProps, this.onEditNode,
+                  this.state.currentNode, assessmentNodeProps, this.onEditNode,
                   this.onNodeRemove, this.onFocus, this.canRemoveNode(), this)}
               </div>
             </div>

--- a/src/editors/document/assessment/PageSelection.tsx
+++ b/src/editors/document/assessment/PageSelection.tsx
@@ -64,6 +64,9 @@ export class PageSelection extends React.PureComponent<PageSelectionProps, {}> {
 
           <ContentContainer
             {...this.props}
+            activeContentGuid={null}
+            hover={null}
+            onUpdateHover={() => {}}
             parent={null}
             onFocus={this.props.onFocus}
             model={page.title.text}

--- a/src/editors/document/common/questions.tsx
+++ b/src/editors/document/common/questions.tsx
@@ -18,6 +18,9 @@ export type Props = {
   context: AppContext,
   services: AppServices,
   skills: Immutable.OrderedMap<string, Skill>,
+  activeContentGuid: string;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 };
 
 export type EditHandler = (guid: string, node: contentTypes.Node, src) => void;
@@ -43,6 +46,9 @@ export function renderAssessmentNode(
             services={props.services}
             allSkills={props.skills}
             context={props.context}
+            activeContentGuid={props.activeContentGuid}
+            hover={props.hover}
+            onUpdateHover={props.onUpdateHover}
             model={n}
             onEdit={(c, src) => onEdit(n.guid, c, src)}
             canRemove={canRemove}
@@ -58,6 +64,9 @@ export function renderAssessmentNode(
             editMode={props.editMode}
             services={props.services}
             context={props.context}
+            activeContentGuid={props.activeContentGuid}
+            hover={props.hover}
+            onUpdateHover={props.onUpdateHover}
             model={n}
             onEdit={(c, src) => onEdit(n.guid, c, src)}
             onRemove={() => onRemove(n.guid)}
@@ -72,6 +81,9 @@ export function renderAssessmentNode(
             editMode={props.editMode}
             services={props.services}
             context={props.context}
+            activeContentGuid={props.activeContentGuid}
+            hover={props.hover}
+            onUpdateHover={props.onUpdateHover}
             allSkills={props.skills}
             model={n}
             onEdit={(c, src) => onEdit(n.guid, c, src)}

--- a/src/editors/document/org/OrgEditor.tsx
+++ b/src/editors/document/org/OrgEditor.tsx
@@ -334,10 +334,14 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
   renderLabels() {
     return (
       <div className="org-tab">
-        <LabelsEditor {...this.props}
-        parent={null}
-        onFocus={this.onFocus.bind(this)}
-        onEdit={this.onLabelsEdit} model={this.props.model.labels} />
+        <LabelsEditor
+          {...this.props}
+          activeContentGuid={null}
+          hover={null}
+          onUpdateHover={() => {}}
+          parent={null}
+          onFocus={this.onFocus.bind(this)}
+          onEdit={this.onLabelsEdit} model={this.props.model.labels} />
       </div>
     );
   }

--- a/src/editors/document/pool/PoolEditor.controller.ts
+++ b/src/editors/document/pool/PoolEditor.controller.ts
@@ -8,10 +8,12 @@ import { PoolModel } from 'data/models';
 import { ParentContainer, TextSelection } from 'types/active';
 import { Maybe } from 'tsmonad';
 import * as activeActions from 'actions/active';
+import { updateHover } from 'actions/hover';
 
 interface StateProps {
   skills: OrderedMap<string, Skill>;
   activeContext: any;
+  hover: string;
 }
 
 interface DispatchProps {
@@ -20,16 +22,18 @@ interface DispatchProps {
   onUpdateContentSelection: (
     documentId: string, content: Object, container: ParentContainer,
     textSelection: Maybe<TextSelection>) => void;
+  onUpdateHover: (hover: string) => void;
 }
 
 interface OwnProps extends AbstractEditorProps<PoolModel> {}
 
 const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
-  const { activeContext, skills } = state;
+  const { activeContext, skills, hover } = state;
 
   return {
     activeContext,
     skills,
+    hover,
   };
 };
 
@@ -46,6 +50,9 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
       parent: ParentContainer, textSelection: Maybe<TextSelection>) => {
 
       return dispatch(activeActions.updateContext(documentId, content, parent, textSelection));
+    },
+    onUpdateHover: (hover: string) => {
+      return dispatch(updateHover(hover));
     },
   };
 };

--- a/src/editors/document/pool/PoolEditor.tsx
+++ b/src/editors/document/pool/PoolEditor.tsx
@@ -29,6 +29,8 @@ export interface PoolEditorProps extends AbstractEditorProps<models.PoolModel> {
   onUpdateContentSelection: (
     documentId: string, content: Object, container: ParentContainer,
     textSelection: Maybe<TextSelection>) => void;
+  hover: string;
+  onUpdateHover: (hover: string) => void;
 }
 
 interface PoolEditorState extends AbstractEditorState {
@@ -159,6 +161,17 @@ class PoolEditor extends AbstractEditor<models.PoolModel,
 
     const text = this.props.model.resource.title;
 
+
+    const activeContentGuid = this.props.activeContext.activeChild.caseOf({
+      just: c => (c as any).guid,
+      nothing: () => '',
+    });
+
+    const assesmentNodeProps = {
+      ...this.props,
+      activeContentGuid,
+    };
+
     return (
       <div className="pool-editor">
         <h2 className="title-row">{text}</h2>
@@ -184,7 +197,7 @@ class PoolEditor extends AbstractEditor<models.PoolModel,
               </div>
               <div className="nodeContainer">
                 {renderAssessmentNode(
-                  this.state.currentNode, this.props, this.onEdit,
+                  this.state.currentNode, assesmentNodeProps, this.onEdit,
                   this.onRemove, this.onFocus,
                   true, null)}
               </div>

--- a/src/editors/document/workbook/Details.tsx
+++ b/src/editors/document/workbook/Details.tsx
@@ -51,6 +51,9 @@ export class Details
           <div className="col-11">
             <ContentContainer
               {...this.props}
+              activeContentGuid={null}
+              hover={null}
+              onUpdateHover={() => {}}
               editMode={this.props.editMode}
               model={this.props.model.head.title.text}
               onEdit={this.onTitleEdit} />

--- a/src/editors/document/workbook/WorkbookPageEditor.tsx
+++ b/src/editors/document/workbook/WorkbookPageEditor.tsx
@@ -112,6 +112,9 @@ class WorkbookPageEditor extends AbstractEditor<models.WorkbookPageModel,
     return (
       <Objectives
         {...this.props}
+        activeContentGuid={null}
+        hover={null}
+        onUpdateHover={() => {}}
         model={this.props.model.head.objrefs}
         onFocus={() => {}}
         onEdit={this.onObjectivesEdit}/>


### PR DESCRIPTION
KNOWN ISSUE: Editing of default feedback for some questions doesn't work. This will be resolved in another bug tracker

fix template typo
remove left radius from contigText when selected
other various improvements
hover props are now required for ContentContainer