### PR TITLE
add space removal to details in org editor

### DIFF
--- a/src/editors/content/learning/AlternativeEditor.tsx
+++ b/src/editors/content/learning/AlternativeEditor.tsx
@@ -39,7 +39,7 @@ export default class AlternativeEditor
   }
 
   onValueEdit(value: string) {
-    const spacesStripped = value.replace(' ', '');
+    const spacesStripped = value.replace(/\s+/g, '');
     const model = this.props.model.with({ value: spacesStripped });
     this.props.onEdit(model, model);
   }

--- a/src/editors/document/org/Details.tsx
+++ b/src/editors/document/org/Details.tsx
@@ -30,28 +30,27 @@ export class Details
     this.onProductEdit = this.onProductEdit.bind(this);
   }
 
-  onTitleEdit(title) {
+  onTitleEdit(title: string) {
     const resource = this.props.model.resource.with({ title });
     this.props.onEdit(this.props.model.with({ title, resource }));
   }
 
-  onAudienceEdit(audience) {
+  onAudienceEdit(audience: string) {
     this.props.onEdit(this.props.model.with({ audience }));
   }
 
-  onDescEdit(description) {
+  onDescEdit(description: string) {
     this.props.onEdit(this.props.model.with({ description }));
   }
 
-  onVersionEdit(version) {
+  onVersionEdit(version: string) {
     this.props.onEdit(this.props.model.with({ version }));
   }
 
-  onProductEdit(product) {
-    this.props.onEdit(this.props.model.with({ product: Maybe.just<string>(product) }));
+  onProductEdit(product: string) {
+    const spacesStripped = product.replace(/\s+/g, '');
+    this.props.onEdit(this.props.model.with({ product: Maybe.just<string>(spacesStripped) }));
   }
-
-
 
   render() {
 


### PR DESCRIPTION
Changed .replace method in AlternativeEditor to be a global replace - .replace only replaces the first instance of a match when a string literal is used instead of a regex expression.