### PR TITLE
fix textinput update issue

### DIFF
--- a/src/editors/content/common/TextInput.tsx
+++ b/src/editors/content/common/TextInput.tsx
@@ -26,7 +26,9 @@ export class TextInput extends React.PureComponent<TextInputProps, TextInputStat
   componentDidUpdate(nextProps) {
     // set cursor to correct position. Fixes an issue with react controlled inputs
     // https://searler.github.io/react.js/2014/04/11/React-controlled-text.html
-    this.ref.setSelectionRange(this.caret, this.caret);
+    if (this.ref.type === 'text') {
+      this.ref.setSelectionRange(this.caret, this.caret);
+    }
   }
 
   onChange(e) {


### PR DESCRIPTION
TextInput doesn't update its value when pushed from props. This was introduced by a previous fix for cursor position. Both issues are addressed in this fix