### PR TITLE
preserve bib:file, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "",
   "main": "./src/app.tsx",
   "author": "",


### PR DESCRIPTION
Preserve (but do not parse, yet) the bib:file section that may exist in a workbook page. Without doing this, pages that contain bib:file would have the bib:file stripped out, which in addition to being loss of data results in the inability to even save that page due to dangling idrefs in cites.

