### PR TITLE
tweak sizes to allow itemtoolbar to render correctly in FF

### DIFF
--- a/src/components/toolbar/ContextAwareToolbar.tsx
+++ b/src/components/toolbar/ContextAwareToolbar.tsx
@@ -243,7 +243,7 @@ export class ContextAwareToolbar extends React.Component<StyledComponentProps<To
             onDismissModal={onDismissModal} />
         </ToolbarGroup>
 
-        <ToolbarGroup className={classes.toolbarItemGroup} label="Item" columns={6.7}>
+        <ToolbarGroup className={classes.toolbarItemGroup} label="Item" columns={7}>
           <ItemToolbar
             context={context}
             parentSupportsElementType={parentSupportsElementType} />

--- a/src/components/toolbar/ItemToolbar.tsx
+++ b/src/components/toolbar/ItemToolbar.tsx
@@ -86,14 +86,14 @@ export class ItemToolbar extends React.PureComponent<ItemToolbarProps & JSSProps
           <ToolbarButton
             onClick={() => onCut(this.getItem())}
             tooltip="Cut Item"
-            size={ToolbarButtonSize.Full}
+            size={ToolbarButtonSize.Wide}
             disabled={!(this.hasSelection() && this.canDuplicate())}>
             <i className="fa fa-cut" /> Cut
           </ToolbarButton>
           <ToolbarButton
             onClick={() => onCopy(this.getItem())}
             tooltip="Copy Item"
-            size={ToolbarButtonSize.Full}
+            size={ToolbarButtonSize.Wide}
             disabled={!(this.hasSelection() && this.canDuplicate())}>
             <i className="fa fa-copy" /> Copy
           </ToolbarButton>

--- a/src/components/toolbar/ToolbarButton.styles.ts
+++ b/src/components/toolbar/ToolbarButton.styles.ts
@@ -67,8 +67,8 @@ export const styles: JSSStyles = {
       },
     },
     '&.wide': {
-      minWidth: 84,
-      maxWidth: 84,
+      minWidth: 86,
+      maxWidth: 86,
       height: 32,
       textAlign: 'left',
 


### PR DESCRIPTION
Adjusts the widths of the ItemToolbar and buttons inside of it to avoid layout problems in Firefox