### PR TITLE
add null check

### DIFF
--- a/src/components/ResourceView.tsx
+++ b/src/components/ResourceView.tsx
@@ -46,7 +46,7 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
 
   componentWillReceiveProps(nextProps: ResourceViewProps): void {
     if (nextProps.resourceType !== this.props.resourceType &&
-        nextProps.title !== this.props.title) {
+      nextProps.title !== this.props.title) {
       this.setState({
         resources: this.getFilteredRows(nextProps),
       });
@@ -129,7 +129,7 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
     const text = searchText.trim().toLowerCase();
     const filterFn = (r: Resource): boolean => {
       const { title, id } = r;
-      const titleLower = title ? title.toLowerCase(): '';
+      const titleLower = title ? title.toLowerCase() : '';
       const idLower = id ? id.toLowerCase() : '';
 
       return text === '' ||


### PR DESCRIPTION
I'm not sure why this null check is needed, the 'r' parameter that is provided to the filterFn is a Resource, which has both 'id' and 'title' as string props. But this fixes the issue.