### PR TITLE
removed default static content

### DIFF
--- a/src/data/content/learning/composite.ts
+++ b/src/data/content/learning/composite.ts
@@ -24,7 +24,7 @@ const defaultContent = {
   title: Maybe.nothing(),
   purpose: Maybe.nothing(),
   instructions: Maybe.nothing(),
-  content: ContentElements.fromText('Content', '', BOX_ELEMENTS),
+  content: new ContentElements().with({ supportedElements: Immutable.List<string>(BOX_ELEMENTS) }),
   guid: '',
 };
 

--- a/src/data/content/learning/example.ts
+++ b/src/data/content/learning/example.ts
@@ -21,7 +21,7 @@ const defaultContent = {
   id: Maybe.nothing(),
   title: Title.fromText('Title'),
   purpose: Maybe.nothing(),
-  content: ContentElements.fromText('Content', '', BOX_ELEMENTS),
+  content: new ContentElements().with({ supportedElements: Immutable.List<string>(BOX_ELEMENTS) }),
   guid: '',
 };
 

--- a/src/data/content/learning/figure.ts
+++ b/src/data/content/learning/figure.ts
@@ -31,7 +31,7 @@ const defaultContent = {
   title: Title.fromText('Title'),
   caption: Maybe.nothing(),
   cite: Maybe.nothing(),
-  content: ContentElements.fromText('Content', '', BOX_ELEMENTS),
+  content: new ContentElements().with({ supportedElements: Immutable.List<string>(BOX_ELEMENTS) }),
 };
 
 export class Figure extends Immutable.Record(defaultContent) {

--- a/src/data/content/learning/material.ts
+++ b/src/data/content/learning/material.ts
@@ -11,7 +11,8 @@ export type MaterialParams = {
 const defaultContent = {
   contentType: 'Material',
   elementType: 'material',
-  content: new ContentElements().with({ supportedElements: Immutable.List(MATERIAL_ELEMENTS) }),
+  content: new ContentElements().with(
+    { supportedElements: Immutable.List<string>(MATERIAL_ELEMENTS) }),
   guid: '',
 };
 

--- a/src/data/content/learning/pullout.ts
+++ b/src/data/content/learning/pullout.ts
@@ -45,7 +45,7 @@ const defaultContent = {
   title: Title.fromText('Title'),
   orient: Orientation.Horizontal,
   pulloutType: Maybe.nothing(),
-  content: ContentElements.fromText('Content', '', BOX_ELEMENTS),
+  content: new ContentElements().with({ supportedElements: Immutable.List<string>(BOX_ELEMENTS) }),
   guid: '',
 };
 

--- a/src/data/content/workbook/section.ts
+++ b/src/data/content/workbook/section.ts
@@ -24,7 +24,7 @@ const defaultContent = {
   id: Maybe.nothing(),
   title: Title.fromText('New Section Title'),
   purpose: Maybe.nothing(),
-  body: ContentElements.fromText('', '', [...BODY_ELEMENTS, ...WB_BODY_EXTENSIONS]),
+  body: new ContentElements().with({ supportedElements: Immutable.List<string>(BODY_ELEMENTS) }),
   guid: '',
 };
 


### PR DESCRIPTION
This PR fixes a problem where if the user creates two or more sections in the same editing session, the contiguous text editors in each of those sections will highlight as the 'active' item when the other editor is selected.

The root cause is duplication of guids due to erroneous specification of default content in the data wrappers.  The ContentElements.fromText method internally creates a structure that contains a contiguous text element with a random guid.  This ContentElements.fromText result is stamped into every new section instance, thus duplicating the contiguous text and it's guid.  So when multiple sections are created, every section has a contiguous text instance all sharing the same guid - and thus all getting highlighted when 'active'

The problem existed for a handful of other wrappers too.
