### PR TITLE
Authoring 1201 pool rendering

### DIFF
--- a/src/editors/document/pool/PoolEditor.tsx
+++ b/src/editors/document/pool/PoolEditor.tsx
@@ -99,10 +99,6 @@ class PoolEditor extends AbstractEditor<models.PoolModel,
       // for instance, from an undo/redo
       const { model, activeContext, onSetCurrentNode } = this.props;
 
-      const currentNodeGuid = nextProps.currentNode.caseOf({
-        just: currentNode => currentNode.guid,
-        nothing: () => '',
-      });
       const previousNodeGuid = this.props.currentNode.caseOf({
         just: currentNode => currentNode.guid,
         nothing: () => '',


### PR DESCRIPTION
This PR fixes two problems in the question pool editor:

1) Questions could not be edited.  The problem was that the currentNode in the global reducer was not being set on edit.

2) Undo/redo did not update the UI. The problem was the logic in the CWRP method that attempts to set the current node.