### PR TITLE
add default feedback for numeric and text inputs

### DIFF
--- a/src/editors/content/question/MultipartInput.tsx
+++ b/src/editors/content/question/MultipartInput.tsx
@@ -131,7 +131,7 @@ export class MultipartInput extends Question<MultipartInputProps, MultipartInput
 
     if (result !== null) {
       const item = new contentTypes.Text().with({ id: result[1] });
-      const part = this.buildPartWithInitialResponse('');
+      const part = this.buildPartWithInitialResponse('answer');
 
       this.props.onAddItemPart(item, part, result[0]);
     }


### PR DESCRIPTION
This PR changes the creation logic for Text and Numeric input based item parts to include two responses: one as a default "correct" response and the second as the "other" feedback.

I wanted to leave the "match" attributes empty, but that ends up having the entire response filtered out (see the content wrapper logic in part.ts, it filters out responses whose match attributes are the empty string due to OLI constraints). Having these filtered out is only bad in the case that the user doesn't fill something in, leaves the assessment and reloads it. In that case, there will be no default feedback.  So to prevent this we simply set the default match attribute to be some useful, non empty-string value.  

Risk: Low, this is an isolated change to one spot in the code where we create new inputs
Stability: High, I tested this and it works well