### PR TITLE
remove improperly constructed Content

### DIFF
--- a/src/components/sidebar/ContextAwareSidebar.tsx
+++ b/src/components/sidebar/ContextAwareSidebar.tsx
@@ -17,7 +17,6 @@ import {
 import { AppContext } from 'editors/common/AppContext';
 import { AppServices } from 'editors/common/AppServices';
 import { PageSelection } from 'editors/document/assessment/PageSelection.tsx';
-import guid from 'utils/guid';
 import { createMultipleChoiceQuestion } from 'editors/content/question/AddQuestion';
 import { TextInput } from 'editors/content/common/TextInput';
 import { LegacyTypes } from 'data/types';
@@ -176,14 +175,10 @@ export class ContextAwareSidebar
     let page = new contentTypes.Page()
       .with({ title: contentTypes.Title.fromText(text) });
 
-    let content = new contentTypes.Content();
-    content = content.with({ guid: guid() });
-
     const question = createMultipleChoiceQuestion('single');
 
     page = page.with({
-      nodes: page.nodes.set(content.guid, content)
-        .set(question.guid, question),
+      nodes: page.nodes.set(question.guid, question),
     });
 
     onEditModel(


### PR DESCRIPTION
This PR fixes a problem with attempting to select a page immediately after creating it.

The root cause was an incompletely constructed contentTypes.Content object. Downstream a renderer from tabs.tsx attempts to access the first element in the content body - since it has none it throws an error. 

I don't think that we need this supporting content in a new page, so I'm just removing it. 

Risk: Very low, isolated to only the Add Page feature
Stability: High, tested and it fixes the problem