### PR TITLE
handle missing resource case

### DIFF
--- a/src/editors/content/learning/ActivityEditor.tsx
+++ b/src/editors/content/learning/ActivityEditor.tsx
@@ -112,9 +112,15 @@ export default class ActivityEditor
   renderMain() {
     const { classes } = this.props;
 
+    const resource = this.props.context.courseModel.resourcesById.get(this.props.model.idref);
+
+    const titleOrPlaceholder = resource !== undefined
+      ? resource.title
+      : 'Loading...';
+
     return (
       <div className={classes.activity}>
-        <h5>{this.props.context.courseModel.resourcesById.get(this.props.model.idref).title}</h5>
+        <h5>{titleOrPlaceholder}</h5>
         <button
           onClick={this.onClick}
           type="button"


### PR DESCRIPTION
This PR updates the ActivityEditor component to be robust in the case where an idref points to a resource that is missing from the course model resources map.

A similar piece of functionality already existed in WbInlineEditor.tsx

Risk: Very low, isolated to the ActivityEditor component
Stability: Medium/High, this should fix the problem but it is difficult to test as you have to have a missing resource