### PR TITLE
release documents on unload

### DIFF
--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -231,6 +231,13 @@ export function load(courseId: string, documentId: string) {
   };
 }
 
+export function releaseAll() {
+  return function (dispatch, getState) {
+    const documents : EditedDocument[] = getState().documents.toArray();
+    documents.forEach(d => dispatch(release(d.documentId)));
+  };
+}
+
 export function release(documentId: string) {
   return function (dispatch, getState) {
     const editedDocument: EditedDocument = getState().documents.get(documentId);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,7 +16,7 @@ import { loadCourse } from 'actions/course';
 import { AppContainer } from 'react-hot-loader';
 import initEditorRegistry from './editors/manager/registrar';
 import { registerContentTypes } from 'data/registrar';
-
+import { releaseAll } from 'actions/document';
 import { ApplicationRoot } from './ApplicationRoot';
 
 // import application styles
@@ -142,6 +142,7 @@ function clearHeldLocks() {
 
 window.addEventListener('beforeunload', (event) => {
   if (store !== null) {
+    store.dispatch(releaseAll());
     store.dispatch(clearHeldLocks());
   }
 });


### PR DESCRIPTION
This PR wires into the beforeunload listener the release of all edited documents. This effectively flushes any and all pending changes if the user closes the browser or presses the "Refresh" button.

RISK: Low
STABILITY: Medium, in testing this I can still lose changes if I *very* quickly press refresh after typing some characters in contiguous text.  But for the most part this addresses the problem. When we add the display of "Autosaving your changes" it will then be straightforward to detect when there are pending changes and do something more robust