### PR TITLE
clean up toggle switch interface, label defaults to after

### DIFF
--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -8,15 +8,14 @@ export interface ToggleSwitchProps {
   style?: any;
   checked?: boolean;
   onClick?: (e) => void;
-  labelBefore?: string;
-  labelAfter?: string;
+  label: string;
 }
 
 /**
  * React Stateless ToggleSwitch
  */
 export const ToggleSwitch: React.StatelessComponent<ToggleSwitchProps> = ({
-  className, style, checked, onClick, labelBefore, labelAfter, editMode,
+  className, style, checked, onClick, label, editMode,
 }) => {
   const disabled = (editMode !== undefined && !editMode);
 
@@ -24,7 +23,6 @@ export const ToggleSwitch: React.StatelessComponent<ToggleSwitchProps> = ({
     <div
       className={`toggle-switch ${className || ''} ${disabled && 'disabled'}`}
       style={style} onClick={e => !disabled && onClick(e)}>
-      {labelBefore && <span className="label before">{labelBefore}</span>}
       <input
         className="toggle toggle-light"
         type="checkbox"
@@ -32,7 +30,7 @@ export const ToggleSwitch: React.StatelessComponent<ToggleSwitchProps> = ({
         disabled={disabled}
         checked={checked || false} />
       <label className="toggle-btn"></label>
-      {labelAfter && <span className="label after">{labelAfter}</span>}
+      {label && <span className="label after">{label}</span>}
     </div>
   );
 };

--- a/src/editors/content/common/TabContainer.tsx
+++ b/src/editors/content/common/TabContainer.tsx
@@ -145,17 +145,17 @@ export const TabSection: React.StatelessComponent<TabSectionProps> = ({ classNam
 type TabOptionControlProps = {
   className?: string;
   name: string,
-  hideLabel?: boolean,
+  label?: string,
   onClick?: (e, name: string) => void;
 };
 
 export const TabOptionControl: React.StatelessComponent<TabOptionControlProps>
-  = ({ name, hideLabel, onClick, children, className }) => (
+  = ({ name, label, onClick, children, className }) => (
   <div
     className={`control clickable ${convertStringToCSS(name)} ${className || ''}`}
     onClick={e => onClick && onClick(e, name)}>
-    {!hideLabel &&
-      <div className="control-label">{name}</div>
+    {label &&
+      <div className="control-label">{label}</div>
     }
     {children}
   </div>

--- a/src/editors/content/items/DynaDropTargetItems.tsx
+++ b/src/editors/content/items/DynaDropTargetItems.tsx
@@ -146,9 +146,11 @@ DynaDropTargetItems
     return (
       <TabSection className="targets">
       <TabSectionHeader title="Label">
-        <TabOptionControl key="advanced" name="">
+        <TabOptionControl name="advanced">
           <ToggleSwitch
-            labelBefore="Advanced" checked={advancedScoring} onClick={onToggleAdvanced} />
+            checked={advancedScoring}
+            label="Advanced"
+            onClick={onToggleAdvanced} />
         </TabOptionControl>
       </TabSectionHeader>
       <TabSectionContent>

--- a/src/editors/content/items/FillInTheBlank.tsx
+++ b/src/editors/content/items/FillInTheBlank.tsx
@@ -219,7 +219,7 @@ FillInTheBlank
     return (
       <TabSection className="choices">
         <TabSectionHeader title="Choices">
-          <TabOptionControl key="add-choice" name="Add Choice" hideLabel>
+          <TabOptionControl name="add-choice">
             <Button
               editMode={editMode}
               type="link"
@@ -227,8 +227,11 @@ FillInTheBlank
               Add Choice
             </Button>
           </TabOptionControl>
-          <TabOptionControl key="shuffle" name="Shuffle" onClick={this.onToggleShuffle}>
-            <ToggleSwitch checked={itemModel.shuffle} />
+          <TabOptionControl name="shuffle">
+            <ToggleSwitch
+              checked={itemModel.shuffle}
+              label="Shuffle"
+              onClick={this.onToggleShuffle} />
           </TabOptionControl>
         </TabSectionHeader>
         <TabSectionContent>

--- a/src/editors/content/items/Numeric.tsx
+++ b/src/editors/content/items/Numeric.tsx
@@ -99,7 +99,7 @@ export class Numeric
           </Select>
         </TabSectionContent>
         <TabSectionHeader title="Feedback">
-          <TabOptionControl key="add-feedback" name="Add Feedback" hideLabel>
+          <TabOptionControl name="add-feedback">
             <Button
               editMode={editMode}
               type="link"

--- a/src/editors/content/items/Text.tsx
+++ b/src/editors/content/items/Text.tsx
@@ -133,7 +133,7 @@ export class Text
             onEdit={this.onCaseSensitive} />
         </TabSectionContent>
         <TabSectionHeader title="Feedback">
-          <TabOptionControl key="add-feedback" name="Add Feedback" hideLabel>
+          <TabOptionControl name="add-feedback">
             <Button
               editMode={editMode}
               type="link"

--- a/src/editors/content/learning/AppletEditor.tsx
+++ b/src/editors/content/learning/AppletEditor.tsx
@@ -103,10 +103,9 @@ export default class AppletEditor
 
         <SidebarGroup label="Logging">
           <ToggleSwitch
-            {...this.props}
             checked={model.logging}
             onClick={this.onLoggingToggle}
-            labelBefore="Enabled" />
+            label="Enabled" />
         </SidebarGroup>
 
         <MediaWidthHeightEditor

--- a/src/editors/content/learning/AudioEditor.tsx
+++ b/src/editors/content/learning/AudioEditor.tsx
@@ -105,7 +105,7 @@ export default class AudioEditor
           <ToggleSwitch
             checked={this.props.model.controls}
             onClick={this.onControlEdit}
-            labelBefore="Display audio controls" />
+            label="Display audio controls" />
         </SidebarGroup>
         <MediaMetadataEditor
           {...this.props}

--- a/src/editors/content/learning/CustomEditor.tsx
+++ b/src/editors/content/learning/CustomEditor.tsx
@@ -91,10 +91,9 @@ export class CustomEditor
           </SidebarRow>
           <SidebarRow label="Logging">
             <ToggleSwitch
-              {...this.props}
               checked={model.logging}
               onClick={() => onEdit(model.with({ logging: !model.logging }))}
-              labelBefore="Enabled" />
+              label="Enabled" />
           </SidebarRow>
         </SidebarGroup>
       </SidebarContent>

--- a/src/editors/content/learning/FlashEditor.tsx
+++ b/src/editors/content/learning/FlashEditor.tsx
@@ -101,10 +101,9 @@ export default class FlashEditor
 
         <SidebarGroup label="Logging">
           <ToggleSwitch
-            {...this.props}
             checked={model.logging}
             onClick={this.onLoggingToggle}
-            labelBefore="Enabled" />
+            label="Enabled" />
         </SidebarGroup>
 
         <MediaWidthHeightEditor

--- a/src/editors/content/learning/ImageEditor.tsx
+++ b/src/editors/content/learning/ImageEditor.tsx
@@ -219,14 +219,13 @@ export class ImageSizeSidebar extends
           </SidebarRow>
           <SidebarRow label="">
             <ToggleSwitch
-              {...this.props}
               editMode={this.props.editMode &&
                 this.state.isSizeReceived &&
                 !this.state.isNativeSize}
               checked={this.state.isProportionConstrained}
               onClick={() =>
                 this.onToggleProportionContrained(!this.state.isProportionConstrained)}
-              labelBefore="Maintain Aspect Ratio" />
+              label="Maintain Aspect Ratio" />
           </SidebarRow>
         </SidebarGroup>
       </div>

--- a/src/editors/content/learning/MediaItems.tsx
+++ b/src/editors/content/learning/MediaItems.tsx
@@ -175,10 +175,9 @@ export class MediaMetadataEditor
         </SidebarGroup>
         <SidebarGroup label="Popout">
           <ToggleSwitch
-            {...this.props}
             checked={popout.enable}
             onClick={this.onPopoutEnableToggle}
-            labelBefore="Enabled" />
+            label="Enabled" />
           <TextInput width="100%" label="Content"
             editMode={this.props.editMode}
             value={popout.content}

--- a/src/editors/content/learning/PulloutEditor.tsx
+++ b/src/editors/content/learning/PulloutEditor.tsx
@@ -99,7 +99,7 @@ export default class PulloutEditor
             editMode={this.props.editMode}
             checked={this.isOrientVertical()}
             onClick={() => this.onEditOrient(!this.isOrientVertical())}
-            labelBefore="Vertical" />
+            label="Vertical" />
 
         </ToolbarLayout.Column>
 

--- a/src/editors/content/learning/VideoEditor.tsx
+++ b/src/editors/content/learning/VideoEditor.tsx
@@ -111,7 +111,7 @@ export default class VideoEditor
           <ToggleSwitch
             checked={this.props.model.controls}
             onClick={this.onControlEdit}
-            labelBefore="Display video controls" />
+            label="Display video controls" />
         </SidebarGroup>
 
         <MediaWidthHeightEditor

--- a/src/editors/content/learning/YouTubeEditor.tsx
+++ b/src/editors/content/learning/YouTubeEditor.tsx
@@ -91,7 +91,7 @@ export default class YouTubeEditor
           <ToggleSwitch
             checked={this.props.model.controls}
             onClick={this.onControlEdit}
-            labelBefore="Display YouTube controls" />
+            label="Display YouTube controls" />
         </SidebarGroup>
         <MediaWidthHeightEditor
           width={this.props.model.width}

--- a/src/editors/content/learning/table/CellEditor.tsx
+++ b/src/editors/content/learning/table/CellEditor.tsx
@@ -156,11 +156,10 @@ export default class CellEditor
         </SidebarGroup>
         <SidebarGroup label="Header">
           <ToggleSwitch
-            {...this.props}
             checked={this.props.model.contentType === 'CellHeader'}
             onClick={() =>
               this.onToggleCellHeader()}
-            labelBefore="Display cell as a header" />
+            label="Display cell as a header" />
         </SidebarGroup>
       </SidebarContent>
     );

--- a/src/editors/content/question/CheckAllThatApply.tsx
+++ b/src/editors/content/question/CheckAllThatApply.tsx
@@ -424,7 +424,7 @@ export class CheckAllThatApply extends Question<CheckAllThatApplyProps, CheckAll
       <React.Fragment>
         <TabSection key="choices" className="choices">
           <TabSectionHeader title="Choices">
-            <TabOptionControl key="add-choice" name="Add Choice" hideLabel>
+            <TabOptionControl name="add-choice">
               <Button
                 editMode={editMode}
                 type="link"
@@ -432,11 +432,17 @@ export class CheckAllThatApply extends Question<CheckAllThatApplyProps, CheckAll
                 Add Choice
               </Button>
             </TabOptionControl>
-            <TabOptionControl key="shuffle" name="Shuffle" onClick={this.onToggleShuffle}>
-              <ToggleSwitch checked={itemModel.shuffle} />
+            <TabOptionControl name="shuffle">
+              <ToggleSwitch
+                checked={itemModel.shuffle}
+                label="Shuffle"
+                onClick={this.onToggleShuffle} />
             </TabOptionControl>
-            <TabOptionControl key="advanced" name="Advanced" onClick={this.onToggleAdvanced}>
-              <ToggleSwitch checked={advancedScoring} />
+            <TabOptionControl name="advanced">
+              <ToggleSwitch
+                checked={advancedScoring}
+                label="Advanced"
+                onClick={this.onToggleAdvanced} />
             </TabOptionControl>
           </TabSectionHeader>
           <TabSectionContent>
@@ -450,7 +456,7 @@ export class CheckAllThatApply extends Question<CheckAllThatApplyProps, CheckAll
           <TabSectionHeader title="Feedback">
             {advancedScoring
               ? (
-                <TabOptionControl key="add-feedback" name="Add Feedback" hideLabel>
+                <TabOptionControl name="add-feedback">
                   <Button
                     editMode={editMode}
                     type="link"

--- a/src/editors/content/question/Essay.tsx
+++ b/src/editors/content/question/Essay.tsx
@@ -69,7 +69,7 @@ export class Essay
     return (
       <TabSection key="choices" className="choices">
         <TabSectionHeader title="Feedback">
-          <TabOptionControl key="add-feedback" name="Add Feedback" hideLabel>
+          <TabOptionControl name="add-feedback">
             <Button
               editMode={editMode}
               type="link"

--- a/src/editors/content/question/ImageHotspot.tsx
+++ b/src/editors/content/question/ImageHotspot.tsx
@@ -239,9 +239,9 @@ export class ImageHotspot
       <React.Fragment>
         <TabSection key="choices" className="choices">
           <TabSectionHeader title="Hotspots">
-            <TabOptionControl key="advancedscoring" name="" >
+            <TabOptionControl name="advancedscoring">
               <ToggleSwitch
-                labelBefore="Advanced"
+                label="Advanced"
                 checked={advancedScoring}
                 onClick={this.onToggleAdvanced}/>
             </TabOptionControl>

--- a/src/editors/content/question/MultipleChoice.tsx
+++ b/src/editors/content/question/MultipleChoice.tsx
@@ -306,7 +306,7 @@ export class MultipleChoice
       <React.Fragment>
         <TabSection key="choices" className="choices">
           <TabSectionHeader title="Choices">
-            <TabOptionControl key="add-choice" name="Add Choice" hideLabel>
+            <TabOptionControl name="add-choice">
               <Button
                 editMode={editMode}
                 type="link"
@@ -314,11 +314,17 @@ export class MultipleChoice
                 Add Choice
               </Button>
             </TabOptionControl>
-            <TabOptionControl key="shuffle" name="Shuffle" onClick={this.onToggleShuffle}>
-              <ToggleSwitch checked={itemModel.shuffle} />
+            <TabOptionControl name="shuffle">
+              <ToggleSwitch
+                checked={itemModel.shuffle}
+                label="Shuffle"
+                onClick={this.onToggleShuffle} />
             </TabOptionControl>
-            <TabOptionControl key="advancedscoring" name="Advanced" onClick={this.onToggleAdvanced}>
-              <ToggleSwitch checked={advancedScoring} />
+            <TabOptionControl name="advancedscoring">
+              <ToggleSwitch
+                checked={advancedScoring}
+                label="Advanced"
+                onClick={this.onToggleAdvanced} />
             </TabOptionControl>
           </TabSectionHeader>
           <TabSectionContent>

--- a/src/editors/content/question/Ordering.tsx
+++ b/src/editors/content/question/Ordering.tsx
@@ -183,7 +183,7 @@ export class Ordering extends Question<OrderingProps, OrderingState> {
       <React.Fragment>
         <TabSection key="choices" className="choices">
           <TabSectionHeader title="Choices">
-            <TabOptionControl key="add-choice" name="Add Choice" hideLabel>
+            <TabOptionControl name="add-choice">
               <Button
                 editMode={editMode}
                 type="link"
@@ -191,8 +191,11 @@ export class Ordering extends Question<OrderingProps, OrderingState> {
                 Add Choice
               </Button>
             </TabOptionControl>
-            <TabOptionControl key="shuffle" name="Shuffle" onClick={this.onToggleShuffle}>
-              <ToggleSwitch checked={itemModel.shuffle} />
+            <TabOptionControl name="shuffle">
+              <ToggleSwitch
+                checked={itemModel.shuffle}
+                label="Shuffle"
+                onClick={this.onToggleShuffle} />
             </TabOptionControl>
           </TabSectionHeader>
           <TabSectionContent>
@@ -203,7 +206,7 @@ export class Ordering extends Question<OrderingProps, OrderingState> {
         </TabSection>
         <TabSection key="feedback" className="feedback">
           <TabSectionHeader title="Feedback">
-            <TabOptionControl key="add-feedback" name="Add Feedback" hideLabel>
+            <TabOptionControl name="add-feedback">
               <Button
                 editMode={editMode}
                 type="link"

--- a/src/editors/content/question/Question.tsx
+++ b/src/editors/content/question/Question.tsx
@@ -272,7 +272,7 @@ export abstract class Question<P extends QuestionProps<contentTypes.QuestionItem
       <Tab className="criteria-tab">
         <TabSection className="criteria">
           <TabSectionHeader title="Grading Criteria">
-            <TabOptionControl key="add-cirteria" name="Add Criteria" hideLabel>
+            <TabOptionControl name="add-cirteria">
               <Button
                 editMode={editMode}
                 type="link"
@@ -309,7 +309,7 @@ export abstract class Question<P extends QuestionProps<contentTypes.QuestionItem
       <Tab className="hints-tab">
         <TabSection className="hints">
           <TabSectionHeader title="Hints">
-            <TabOptionControl key="add-hint" name="Add Hint" hideLabel>
+            <TabOptionControl name="add-hint">
               <Button
                 editMode={this.props.editMode}
                 type="link"


### PR DESCRIPTION
ToggleSwitches are expecting an onClick prop that wasn't provided. Not sure how the compiler let through such that it results in a runtime error. The real issue here is the ToggleButton interface is confusing and inconsistent so it was refactored as part of this bug fix.

RISK: Medium. ToggleSwitch is a basic component and therefore a change to it's interface spans a lot of files
STABILITY: Changes are stable