### PR TITLE
implement auto save notification

### DIFF
--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -10,10 +10,11 @@ import { showMessage, dismissScopedMessages, dismissSpecificMessage } from './me
 import { lookUpByName } from 'editors/manager/registry';
 import { buildPersistenceFailureMessage } from 'utils/error';
 import { buildLockExpiredMessage, buildReadOnlyMessage } from 'utils/lock';
-
+import { Maybe } from 'tsmonad';
 import { logger, LogTag, LogLevel, LogAttribute, LogStyle } from 'utils/logger';
 
-import { PersistenceStrategy } from 'editors/manager/persistence/PersistenceStrategy';
+import { PersistenceStrategy,
+  PersistenceState } from 'editors/manager/persistence/PersistenceStrategy';
 
 export type DOCUMENT_REQUESTED = 'document/DOCUMENT_REQUESTED';
 export const DOCUMENT_REQUESTED: DOCUMENT_REQUESTED = 'document/DOCUMENT_REQUESTED';
@@ -86,35 +87,37 @@ export const modelUpdated = (documentId: string, model: models.ContentModel)
     model,
   });
 
-export type SAVE_INITIATED = 'document/SAVE_INITIATED';
-export const SAVE_INITIATED: SAVE_INITIATED = 'document/SAVE_INITIATED';
+export type IS_SAVING_UPDATED = 'document/IS_SAVING_UPDATED';
+export const IS_SAVING_UPDATED: IS_SAVING_UPDATED = 'document/IS_SAVING_UPDATED';
 
-export type SaveInitiatedAction = {
-  type: SAVE_INITIATED,
+export type IsSavingUpdatedAction = {
+  type: IS_SAVING_UPDATED,
   documentId: string,
+  isSaving: boolean,
 };
 
-export const saveRequestInitiated = (documentId: string)
-  : SaveInitiatedAction => ({
-    type: SAVE_INITIATED,
+export const isSavingUpdated = (documentId: string, isSaving: boolean)
+  : IsSavingUpdatedAction => ({
+    type: IS_SAVING_UPDATED,
     documentId,
+    isSaving,
   });
 
+export type LAST_SAVE_SUCEEDED = 'document/LAST_SAVE_SUCEEDED';
+export const LAST_SAVE_SUCEEDED: LAST_SAVE_SUCEEDED = 'document/LAST_SAVE_SUCEEDED';
 
-export type SAVE_COMPLETED = 'document/SAVE_COMPLETED';
-export const SAVE_COMPLETED: SAVE_COMPLETED = 'document/SAVE_COMPLETED';
-
-export type SaveCompletedAction = {
-  type: SAVE_COMPLETED,
+export type LastSaveSucceededAction = {
+  type: LAST_SAVE_SUCEEDED,
   documentId: string,
+  lastRequestSucceeded: Maybe<boolean>,
 };
 
-export const saveRequestCompleted = (documentId: string)
-  : SaveCompletedAction => ({
-    type: SAVE_COMPLETED,
+export const lastSaveSucceeded = (documentId: string, lastRequestSucceeded: Maybe<boolean>)
+  : LastSaveSucceededAction => ({
+    type: LAST_SAVE_SUCEEDED,
     documentId,
+    lastRequestSucceeded,
   });
-
 
 
 export type DOCUMENT_RELEASED = 'document/DOCUMENT_RELEASED';
@@ -160,7 +163,7 @@ export const changeRedone = (documentId: string): ChangeRedoneAction => ({
 
 function saveCompleted(dispatch, getState, documentId, document) {
 
-  dispatch(saveRequestCompleted(documentId));
+  dispatch(lastSaveSucceeded(documentId, Maybe.just(true)));
 
   dispatch(
     dismissSpecificMessage(new Messages.Message().with({ guid: documentId + '_PERSISTENCE' })));
@@ -168,7 +171,7 @@ function saveCompleted(dispatch, getState, documentId, document) {
 
 function saveFailed(dispatch, getState, courseId, documentId, error) {
 
-  dispatch(saveRequestCompleted(documentId));
+  dispatch(lastSaveSucceeded(documentId, Maybe.just(false)));
 
   const message = error === 'Forbidden'
     ? buildLockExpiredMessage({
@@ -179,8 +182,10 @@ function saveFailed(dispatch, getState, courseId, documentId, error) {
   dispatch(showMessage(message.with({ guid: documentId + '_PERSISTENCE' })));
 }
 
-function saveInitiated(dispatch, getState, courseId, documentId) {
-  dispatch(saveRequestInitiated(documentId));
+function stateChangeListener(
+  dispatch, getState, courseId, documentId, currentState: PersistenceState) {
+
+  dispatch(isSavingUpdated(documentId, currentState.isInFlight || currentState.isPending));
 }
 
 function logResourceDetails(resource: Resource) {
@@ -248,7 +253,7 @@ export function load(courseId: string, documentId: string) {
           document, userName,
           saveCompleted.bind(undefined, dispatch, getState, documentId),
           saveFailed.bind(undefined, dispatch, getState, courseId, documentId),
-          saveInitiated.bind(undefined, dispatch, getState, courseId, documentId),
+          stateChangeListener.bind(undefined, dispatch, getState, courseId, documentId),
         ).then((editingAllowed) => {
 
           if (!editingAllowed) {
@@ -303,6 +308,7 @@ export function save(documentId: string, model: models.ContentModel, isUndoRedo?
     }
 
     const doc = editedDocument.document.with({ model });
+
     editedDocument.persistence.save(doc);
 
   };

--- a/src/components/Header.controller.ts
+++ b/src/components/Header.controller.ts
@@ -1,12 +1,15 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Header from './Header';
+import { Maybe } from 'tsmonad';
 import * as viewActions from 'actions/view';
 
 interface StateProps {
   course: any;
   user: any;
   isSaveInProcess: boolean;
+  lastRequestSucceeded: Maybe<boolean>;
+  saveCount: number;
 }
 
 interface DispatchProps {
@@ -23,12 +26,19 @@ const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
     documents,
   } = state;
 
-  const isSaveInProcess = documents.toArray().some(d => d.saveInProcess);
+  const doc =  documents.toArray().length > 0
+    ? documents.toArray()[0]
+    : { isSaving: false, lastRequestSucceeded: Maybe.nothing(), saveCount: 0 };
+  const isSaveInProcess = doc.isSaving;
+  const lastRequestSucceeded = doc.lastRequestSucceeded;
+  const saveCount = doc.saveCount;
 
   return {
     course,
     user,
     isSaveInProcess,
+    lastRequestSucceeded,
+    saveCount,
   };
 };
 

--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -44,8 +44,9 @@
   }
 
   .save-notification {
-    font-weight: 700;
+    font-weight: 300;
     padding-right: 30px;
+
   }
 
   .course-link {

--- a/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
@@ -3,13 +3,13 @@ import { LockDetails } from '../../../utils/lock';
 
 import {
   onFailureCallback, onSaveCompletedCallback,
-  onBeginSaveCallback, PersistenceStrategy,
+  onStateChangeCallback, PersistenceStrategy,
 } from './PersistenceStrategy';
 
 export interface AbstractPersistenceStrategy {
   successCallback: onSaveCompletedCallback;
   failureCallback: onFailureCallback;
-  beginSaveCallback: onBeginSaveCallback;
+  stateChangeCallback: onStateChangeCallback;
   writeLockedDocumentId: string;
   courseId: string;
   destroyed: boolean;
@@ -21,7 +21,7 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
   constructor() {
     this.successCallback = null;
     this.failureCallback = null;
-    this.beginSaveCallback = null;
+    this.stateChangeCallback = null;
     this.writeLockedDocumentId = null;
     this.courseId = null;
     this.destroyed = false;
@@ -51,12 +51,12 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
   initialize(doc: persistence.Document, userName: string,
              onSuccess: onSaveCompletedCallback,
              onFailure: onFailureCallback,
-             onBeginSave: onBeginSaveCallback,
+             onStateChange: onStateChangeCallback,
             ): Promise<boolean> {
 
     this.successCallback = onSuccess;
     this.failureCallback = onFailure;
-    this.beginSaveCallback = onBeginSave;
+    this.stateChangeCallback = onStateChange;
 
     return new Promise((resolve, reject) => {
 

--- a/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
@@ -37,6 +37,10 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
 
     this.pending = doc;
 
+    if (this.stateChangeCallback !== null) {
+      this.stateChangeCallback({ isInFlight: this.inFlight !== null, isPending: true });
+    }
+
     if (this.inFlight === null) {
       this.queueSave();
     }
@@ -74,8 +78,8 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
       this.inFlight = this.pending;
       this.pending = null;
 
-      if (this.beginSaveCallback !== null) {
-        this.beginSaveCallback();
+      if (this.stateChangeCallback !== null) {
+        this.stateChangeCallback({ isInFlight: true, isPending: false });
       }
 
       persistence.persistDocument(this.inFlight)
@@ -92,6 +96,10 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
 
           this.inFlight = null;
 
+          if (this.stateChangeCallback !== null) {
+            this.stateChangeCallback({ isInFlight: false, isPending: this.pending !== null });
+          }
+
           if (this.pending !== null) {
             this.pending = this.pending.with({ _rev: result._rev });
             this.queueSave();
@@ -99,6 +107,10 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
           resolve(result);
         })
         .catch((err) => {
+
+          if (this.stateChangeCallback !== null) {
+            this.stateChangeCallback({ isInFlight: false, isPending: this.pending !== null });
+          }
 
           this.inFlight = null;
           if (this.failureCallback !== null) {

--- a/src/editors/manager/persistence/ImmediatePersistenceStrategy.ts
+++ b/src/editors/manager/persistence/ImmediatePersistenceStrategy.ts
@@ -9,8 +9,8 @@ export class ImmediatePersistenceStrategy extends AbstractPersistenceStrategy {
 
   save(doc: persistence.Document) {
 
-    if (this.beginSaveCallback !== null) {
-      this.beginSaveCallback();
+    if (this.stateChangeCallback !== null) {
+      this.stateChangeCallback({ isInFlight: true, isPending: false });
     }
 
     this.saveDocument(doc, 3, undefined, undefined)
@@ -18,10 +18,16 @@ export class ImmediatePersistenceStrategy extends AbstractPersistenceStrategy {
         if (this.successCallback !== null) {
           this.successCallback(doc);
         }
+        if (this.stateChangeCallback !== null) {
+          this.stateChangeCallback({ isInFlight: false, isPending: false });
+        }
       })
       .catch((err) => {
         if (this.failureCallback !== null) {
           this.failureCallback(err);
+        }
+        if (this.stateChangeCallback !== null) {
+          this.stateChangeCallback({ isInFlight: false, isPending: false });
         }
       });
   }

--- a/src/editors/manager/persistence/PersistenceStrategy.ts
+++ b/src/editors/manager/persistence/PersistenceStrategy.ts
@@ -5,7 +5,13 @@ export type onSaveCompletedCallback = (lastSavedDocument: persistence.Document) 
 
 export type onFailureCallback = (result: any) => void;
 
-export type onBeginSaveCallback = () => void;
+export type PersistenceState = {
+  isPending: boolean;
+  isInFlight: boolean;
+};
+
+export type onStateChangeCallback = (state: PersistenceState) => void;
+
 
 export interface PersistenceStrategy {
 
@@ -17,7 +23,7 @@ export interface PersistenceStrategy {
                userName: string,
                onSuccess: onSaveCompletedCallback,
                onFailure: onFailureCallback,
-               onBeginSave: onBeginSaveCallback,
+               onStateChange: onStateChangeCallback,
               ) => Promise<boolean>;
 
   /**

--- a/src/reducers/documents.ts
+++ b/src/reducers/documents.ts
@@ -6,8 +6,8 @@ import { ModelTypes, AssessmentModel } from 'data/models';
 import { Maybe } from 'tsmonad';
 
 export type ActionTypes =
-  documentActions.SaveCompletedAction |
-  documentActions.SaveInitiatedAction |
+  documentActions.IsSavingUpdatedAction |
+  documentActions.LastSaveSucceededAction |
   documentActions.ChangeRedoneAction |
   documentActions.ChangeUndoneAction |
   documentActions.DocumentReleasedAction |
@@ -67,13 +67,18 @@ export const documents = (
 
   switch (action.type) {
 
-    case documentActions.SAVE_INITIATED:
+    case documentActions.IS_SAVING_UPDATED:
+      if (state.get(action.documentId) !== undefined) {
+        return state.set(action.documentId, state.get(action.documentId).with({
+          isSaving: action.isSaving,
+        }));
+      }
+      return state;
+
+    case documentActions.LAST_SAVE_SUCEEDED:
       return state.set(action.documentId, state.get(action.documentId).with({
-        saveInProcess: true,
-      }));
-    case documentActions.SAVE_COMPLETED:
-      return state.set(action.documentId, state.get(action.documentId).with({
-        saveInProcess: false,
+        lastRequestSucceeded: action.lastRequestSucceeded,
+        saveCount: state.get(action.documentId).saveCount + 1,
       }));
 
     case documentActions.DOCUMENT_REQUESTED:

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -6,7 +6,6 @@ import { PersistenceStrategy } from 'editors/manager/persistence/PersistenceStra
 import { Maybe } from 'tsmonad';
 import createGuid from 'utils/guid';
 
-
 export type EditedDocumentParams = {
   documentId? : string,
   document?: Document;
@@ -20,7 +19,9 @@ export type EditedDocumentParams = {
   editingAllowed?: boolean;
   currentPage?: Maybe<string>;
   currentNode?: Maybe<contentTypes.Node>;
-  saveInProcess?: boolean;
+  isSaving?: boolean;
+  lastRequestSucceeded?: Maybe<boolean>;
+  saveCount?: number;
 };
 
 const defaultContent = {
@@ -36,7 +37,9 @@ const defaultContent = {
   editingAllowed: false,
   currentPage: Maybe.nothing<string>(),
   currentNode: Maybe.nothing<contentTypes.Node>(),
-  saveInProcess: false,
+  isSaving: false,
+  lastRequestSucceeded: Maybe.nothing(),
+  saveCount: 0,
 };
 
 export class EditedDocument extends Immutable.Record(defaultContent) {
@@ -53,7 +56,9 @@ export class EditedDocument extends Immutable.Record(defaultContent) {
   editingAllowed: boolean;
   currentPage: Maybe<string>;
   currentNode: Maybe<contentTypes.Node>;
-  saveInProcess: boolean;
+  isSaving: boolean;
+  lastRequestSucceeded: Maybe<boolean>;
+  saveCount: number;
 
   constructor(params?: EditedDocumentParams) {
     super(params);


### PR DESCRIPTION
This PR adds the save notification in the Header.

There are changes made here in a few different parts of the application to accomplish this:

1) Enable save request initiation listening in the PersistenceStrategy interface and in the two persistence strategies. This allows client code to register a callback to be notified when a persistence strategy actually sends a save request to the server. With the already existing saveCompleted and saveFailed callbacks, this makes the full lifecycle observable.

2) Using the persistence strategy lifecycle listeners, emit and handle Redux actions to allow tracking of outstanding save requests on a per document basis. 

3) Feed a roll-up of the per document saveInProcess into the Header component and display a "Saving..." notification when necessary.  The intent here is to show this message when *any* document has an in process save.  Right now, of course, we only edit one document at a time.

RISK: Low/medium.  There are changes in the persistence strategy implementations, but there are straightforward and do not affect the existing logic in any way.  

STABILITY: High.  With this in place it is easy to test and see it working. These changes, however, will not affect the CourseEditor - as it does not utilize the redux based document editing. 