### PR TITLE
restrict iframe permissions using sandbox

### DIFF
--- a/src/editors/content/learning/IFrameEditor.tsx
+++ b/src/editors/content/learning/IFrameEditor.tsx
@@ -13,6 +13,7 @@ import {
   Discoverable, DiscoverableId,
 } from 'components/common/Discoverable.controller';
 
+const IFRAME_PERMISSIONS = 'allow-forms allow-scripts';
 
 export interface IFrameEditorProps extends AbstractContentEditorProps<IFrame> {
   onShowSidebar: () => void;
@@ -112,7 +113,7 @@ export default class IFrameEditor
 
     return (
       <div className="iframeEditor">
-        <iframe src={fullSrc} height={height} width={width} sandbox="" />
+        <iframe src={fullSrc} height={height} width={width} sandbox={IFRAME_PERMISSIONS} />
       </div>
     );
   }


### PR DESCRIPTION
Fixes an issue where certain webpages can redirect the editor to a different page.

Risk: Low. May affect rendering of pages that advanced browser features like sessionStorage
Stability: Stable