### PR TITLE
Select most recently uploaded item after file upload in mediaManager

### DIFF
--- a/src/actions/media.ts
+++ b/src/actions/media.ts
@@ -136,7 +136,7 @@ export const fetchCourseMedia = (
         const items = List<MediaItem>(
           response.results.map(item => new FileNode(item.fileNode)));
 
-        // check if the response if for the latest request
+        // check if the response is for the latest request
         if (getState().media.get(courseId).lastReqId === reqId) {
           // request is latest, update state
           dispatch(receiveMediaPage(courseId, items, response.totalResults));

--- a/src/editors/content/media/manager/MediaManager.controller.ts
+++ b/src/editors/content/media/manager/MediaManager.controller.ts
@@ -42,7 +42,7 @@ const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {
 const mapDispatchToProps = (dispatch: Dispatch<State>, ownProps: OwnProps): DispatchProps => {
   return {
     onLoadCourseMediaNextPage: (mimeFilter, searchText, orderBy, order) => {
-      dispatch(fetchCourseMediaNextPage(
+      return dispatch(fetchCourseMediaNextPage(
         ownProps.courseModel.guid, mimeFilter, searchText, orderBy, order));
     },
     onResetMedia: () => {

--- a/src/editors/content/media/manager/MediaManager.tsx
+++ b/src/editors/content/media/manager/MediaManager.tsx
@@ -98,7 +98,7 @@ export interface MediaManagerProps {
   onEdit: (updated: Media) => void;
   onLoadCourseMediaNextPage: (
     mimeFilter: string, searchText: string,
-    orderBy: string, order: string) => void;
+    orderBy: string, order: string) => Promise<Maybe<Immutable.List<MediaItem>>>;
   onResetMedia: () => void;
   onSelectionChange: (selection: MediaItem[]) => void;
   onLoadMediaItemByPath: (path: string) => Promise<Maybe<MediaItem>>;
@@ -240,7 +240,15 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
     createWebContentPromiseFactory(courseModel.guid, fileList.pop())
       .then((result) => {
         onResetMedia();
-        onLoadCourseMediaNextPage(mimeFilter, searchText, orderBy, order);
+        onLoadCourseMediaNextPage(mimeFilter, searchText, orderBy, order)
+          // select the most recently uploaded item
+          .then((mediaItems) => {
+            mediaItems.lift((files) => {
+              if (files.size > 0) {
+                this.onSelect(files.sortBy(file => file.dateUpdated).last().guid);
+              }
+            });
+          });
       });
   }
 


### PR DESCRIPTION
When a file is uploaded to the media manager, the file is now automatically selected in the media items list so that it can be inserted into the page more easily.

Risk: Low, isolated fix
Stability: High, tested with images/audio and with single/multiple file uploads