### PR TITLE
Change publish button spinner color to white

### DIFF
--- a/src/editors/document/org/Actions.tsx
+++ b/src/editors/document/org/Actions.tsx
@@ -68,7 +68,7 @@ export class Actions
       disabled
       className="btn btn-block btn-primary"
       onClick={() => { }}>
-      <LoadingSpinner className="u-no-padding" message="Publishing" />
+      <LoadingSpinner className="u-no-padding text-white" message="Publishing" />
     </button>;
 
     const publishButton = <button


### PR DESCRIPTION
This just changes the spinner color to white which looks better than gray on the blue button background.

Risk: very low, style changes
Stability: stable