### PR TITLE
add hint to disallowed children

### DIFF
--- a/src/components/toolbar/ItemToolbar.tsx
+++ b/src/components/toolbar/ItemToolbar.tsx
@@ -36,7 +36,7 @@ export class ItemToolbar extends React.PureComponent<ItemToolbarProps & JSSProps
   canDuplicate() {
     const { activeContext } = this.props;
 
-    const disallowDuplicates = ['WbInline', 'Activity', 'Speaker', 'Line'];
+    const disallowDuplicates = ['WbInline', 'Activity', 'Speaker', 'Line', 'Hint'];
 
     return activeContext.activeChild.caseOf({
       just: activeChild => activeChild &&


### PR DESCRIPTION
Risk: very low
Stability: stable

Comment copied from jira: We need a way to also determine whether a component is an 'item' in the item toolbar based on the parent component. For example, a hint's contiguous text components should not be able to be copied because the parent (hint) disallows it.