### PR TITLE
Formative assessments: prevent recommended attempts from being higher than maximum attempts

### DIFF
--- a/src/data/models/assessment.ts
+++ b/src/data/models/assessment.ts
@@ -125,13 +125,13 @@ export class AssessmentModel extends Immutable.Record(defaultAssessmentModelPara
       });
     }
     // 2, 3. One value defined
-    if (!isNaN(assessment['@recommended_attempts'])) {
+    if (!isNaN(recommended)) {
       model = model.with({
         recommendedAttempts: assessment['@recommended_attempts'],
         maxAttempts: Math.max(recommended, parseInt(model.maxAttempts, 10)).toString(),
       });
     }
-    if (!isNaN(assessment['@max_attempts'])) {
+    if (!isNaN(maximum)) {
       model = model.with({
         recommendedAttempts: Math.min(parseInt(model.recommendedAttempts, 10), maximum).toString(),
         maxAttempts: assessment['@max_attempts'],


### PR DESCRIPTION
Norm noticed an issue where if you create an assessment by hand (outside the editor) and set the 'recommended' attempts but not the 'maximum' attempts, you can create an error state where the maximum attempts value is set to '3' by the editor as the default value which might be lower than the recommended attempts you chose by hand.

To prevent this, I added logic in the assessment `fromPersistence` method to handle 4 cases:
1. Both recommended and maximum attempts are set in the XML. In that case, use those values as long as the recommended is lower than the maximum
2. Either the recommended or the maximum attempts is already set, so ensure the maximum attempts is higher than the recommended attempts
3. Vice versa of 2.
4. Neither value is set, so just inherit the default parameter values (of '3') for each

Risk: Low/Medium, handles assessment parsing logic but is limited to the recomendedAttempts / maxAttempts properties.
Stability: Stable, tested with new and existing assessments. However, I haven't found a way to test it with an assessment created by hand (outside the editor).