### PR TITLE
check if rawBlock.entityRanges is an empty array

### DIFF
--- a/src/data/content/learning/draft/topersistence.ts
+++ b/src/data/content/learning/draft/topersistence.ts
@@ -126,7 +126,7 @@ function translateBlock(
   if (isParagraphBlock(rawBlock)) {
 
     // If the last block is an empty paragraph, do not translate it
-    if (rawBlock.text === ' ' && iterator.peek() === null) {
+    if (rawBlock.text === ' ' && rawBlock.entityRanges.length === 0 && iterator.peek() === null) {
       return;
     }
 


### PR DESCRIPTION
This fixes an issue where editing a question's answer choices that only contain MathML would strip out the MathML and serialize an empty text block.

The problem is that when we serialize draft entities we are checking if the text of the block is empty. However, structured content (like MathML) does not show up in the text of the draft entity, so we were triggering the case for handling the empty text block and stopping the serialization whenever the block contained only MathML and no text.

The fix is to check if the block's `entityRanges` array is empty. If that is true, then we do have an empty block and have nothing to serialize.

Risk: High, core draft serialization logic
Stability: stable