### PR TITLE
Unstable. add noUnusedLocals

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "noImplicitAny": false,
+        "noUnusedLocals": true,
         "removeComments": false,
         "inlineSources": true,
         "sourceMap": true,


### PR DESCRIPTION
This will warn us in the editor when we have unused local variables like destructured props instead of pushing to github and realizing we have lint errors.

To test, try adding a random import to the top of a file and destructuring props in a method. Both should show warnings.

For some reason this generates compiler errors where it notices unused local variables, but I'm not sure how that's possible.