### PR TITLE
check backingTextProvider for null

### DIFF
--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -229,13 +229,13 @@ export function createNew(model: models.ContentModel) {
 }
 
 export function load(courseId: string, documentId: string) {
-  return function (dispatch, getState) : Promise<boolean> {
+  return function (dispatch, getState) : Promise<any> {
 
     const userName = getState().user.profile.username;
 
     dispatch(documentRequested(documentId));
 
-    persistence.retrieveDocument(courseId, documentId)
+    return persistence.retrieveDocument(courseId, documentId)
       .then((document) => {
 
         // Notify that the course has changed when a user views a course
@@ -269,10 +269,7 @@ export function load(courseId: string, documentId: string) {
           dispatch(documentLoaded(documentId, document, strategy, editingAllowed));
 
         });
-      })
-      .catch(error => console.log('load-error:' + error));
-
-    return Promise.resolve(true);
+      });
   };
 }
 

--- a/src/data/content/learning/draft/todraft.ts
+++ b/src/data/content/learning/draft/todraft.ts
@@ -196,7 +196,9 @@ function inputRefHandler(
   workingBlock.entities.push({ offset, length, key });
 
   const data = extractAttrs(item);
-  data['$type'] = backingTextProvider[item['input_ref']['@input']].contentType;
+  data['$type'] = backingTextProvider
+    ? backingTextProvider[item['input_ref']['@input']].contentType
+    : 'unstyled';
   data[common.CDATA] = item[common.getKey(item)][common.CDATA];
   data[common.TEXT] = item[common.getKey(item)][common.TEXT];
 


### PR DESCRIPTION
Kim discovered an issue where certain e-learning design pages do not load.

Echo: https://echo.oli.cmu.edu/#2c928088643d9a3e01643d9eefd610fa-2c928088643d9a3e01643d9ed12a0b19
Course ID: e_learning_dp
SVN: https://svn.oli.cmu.edu/svn/community/pslc/e_learning_dp/trunk/
Pool ID: m1_pool

The console message is: 
```
load-error:TypeError: Cannot read property 'social_medias_wikis' of null
```
This is caused by 'backingTextProvider' in todraft.js which can possibly be null. The code doesn't check for the null case and so it breaks when backingTextProvider is null. This PR fixes this issue.
- check backingTextProvider for null
- remove catch statement that swallows error

Risk: Medium, touches core draftjs conversion logic
Stability: Appears stable. Tested in a couple different courses and pages

This might be worthy of pushing out as a hotfix