### PR TITLE
save as CDATA

### DIFF
--- a/src/data/content/assessment/variable.ts
+++ b/src/data/content/assessment/variable.ts
@@ -64,7 +64,7 @@ export class Variable extends Immutable.Record(defaultContent) {
 
     const root = { variable: {} };
 
-    root.variable['#text'] = this.expression;
+    root.variable['#cdata'] = this.expression;
     root.variable['@name'] = this.name;
     if (this.id !== '') {
       root.variable['@id'] = this.id;


### PR DESCRIPTION
This PR fixes serialization of variable elements to save them in CDATA sections.  They were already reading as text or cdata.  We need to keep the text reading in place to read in anything serialized as text.