### PR TITLE
fixed contiguous text p content

### DIFF
--- a/src/data/content/learning/composite.ts
+++ b/src/data/content/learning/composite.ts
@@ -99,9 +99,13 @@ export class Composite extends Immutable.Record(defaultContent) {
     this.title.lift(title => optional.push(title.toPersistence()));
     this.instructions.lift(i => optional.push(i.toPersistence()));
 
-    const required = this.content.content.size === 0
-      ? [{ p: { '#text': ' ' } }]
-      : this.content.toPersistence();
+    const encoded = this.content.toPersistence();
+    const required = encoded.length === 0 ? [{
+      p: {
+        '#text': ' ',
+        '@id': createGuid(),
+      },
+    }] : encoded;
 
     const s = {
       composite_activity: {


### PR DESCRIPTION
Contiguous text is now serialized with complete content (a p with text and an id), even when it is just initialized.

Risk: Low
Stability: High (By fixing this in toPersistence, this fixes already broken workbook pages along with newly created composite activities)