### PR TITLE
V0.14.0 - Fix issue with question duplication

### DIFF
--- a/src/data/content/assessment/custom.ts
+++ b/src/data/content/assessment/custom.ts
@@ -63,7 +63,6 @@ export class Custom extends Immutable.Record(defaultContent) {
 
   clone() {
     return ensureIdGuidPresent(this.with({
-      id: createGuid(),
       layout: '',
       layoutData: this.layoutData.lift(ld => ld.clone()),
       src: DYNA_DROP_SRC_FILENAME,

--- a/src/data/content/assessment/question.ts
+++ b/src/data/content/assessment/question.ts
@@ -330,15 +330,14 @@ function cloneDragDropQuestion(question: Question): Question {
       updateHTMLLayoutTargetRefs(valueMap, inputMap, ld)),
   });
 
-  return question.with({
-    id: createGuid(),
+  return ensureIdGuidPresent(question.with({
     body: question.body.with({
       content: question.body.content.set(customContent.guid, clonedCustomContent),
     }).clone(),
     explanation: question.explanation.clone(),
     parts,
     items,
-  });
+  }));
 }
 
 // Cloning a single select multiple choice question requires that
@@ -380,13 +379,12 @@ function cloneMultipleChoiceQuestion(question: Question): Question {
     });
   }).toOrderedMap();
 
-  return question.with({
-    id: createGuid(),
+  return ensureIdGuidPresent(question.with({
     body: question.body.clone(),
     explanation: question.explanation.clone(),
     parts,
     items,
-  });
+  }));
 }
 
 // This ensures that existing input-based questions (aka Numeric, Text, FillInTheBlank)


### PR DESCRIPTION
This PR addresses the fact that not all instances of question cloning used the `ensureIdGuidPresent` function, so question duplication sometimes did not work. I had missed these in the original push to re-write all the clone methods because they don't directly call the data wrappers' clone methods.

Risk: low
Stability: stable