### PR TITLE
fix an issue with cross browser toolbar layout

### DIFF
--- a/src/components/toolbar/ContextAwareToolbar.tsx
+++ b/src/components/toolbar/ContextAwareToolbar.tsx
@@ -264,7 +264,7 @@ export class ContextAwareToolbar extends React.Component<StyledComponentProps<To
         <ToolbarGroup
           className={classes.toolbarActionsGroup}
           label={actionsToolbarLabel()}
-          columns={7.5}>
+          columns={7.6}>
           <ActionsToolbar
             documentResource={resource}
             documentId={context.documentId}


### PR DESCRIPTION
Increase ToolbarGroup column value to fit all actions on toolbar in firefox and edge

**Risk**: Low, simple change
**Stability**: Tested and is stable