### PR TITLE
V0.14.0 - Fix an issue with text selection when emtpy in windows firefox

### DIFF
--- a/src/editors/content/learning/dynadragdrop/DynaDropLabel.styles.ts
+++ b/src/editors/content/learning/dynadragdrop/DynaDropLabel.styles.ts
@@ -5,6 +5,6 @@ export const styles: JSSStyles = {
     position: 'relative',
   },
   labelEditor: {
-
+    minHeight: 24,
   },
 };

--- a/src/editors/content/learning/dynadragdrop/HTMLTableEditor.tsx
+++ b/src/editors/content/learning/dynadragdrop/HTMLTableEditor.tsx
@@ -346,8 +346,6 @@ export class HTMLTableEditor
                 key={cell.guid}
                 id={cell.guid}
                 className={classNames([classes.cell])}
-                // TODO
-                // style={cell.style}
                 canToggleType={true}
                 onToggleType={this.toggleCellType}
                 editMode={editMode}


### PR DESCRIPTION
Fixes an issue where trying to enter text in a drag and drop label cell, when it is empty, is impossible to do on windows firefox. This sets the min height of the label taxt so it can always be selected.

**Risk**: Low. Css change
**Stability**: High, tested and is stable