### PR TITLE
HOTFIX 0.13.4 - Fix an issue where a comma was being inserted at begining of match

### DIFF
--- a/src/editors/content/part/ChoiceFeedback.tsx
+++ b/src/editors/content/part/ChoiceFeedback.tsx
@@ -143,7 +143,6 @@ export abstract class ChoiceFeedback
   }
 
   onEditMatchSelections(responseId, choices, selected) {
-
     const { model, onGetChoiceCombinations, onEdit } = this.props;
 
     const updatedPart = model.with({
@@ -166,11 +165,12 @@ export abstract class ChoiceFeedback
       AUTOGEN_MAX_CHOICES,
       onGetChoiceCombinations,
     );
+
     onEdit(updatedModel, null);
   }
 
   getSelectedMatches(response, choices) {
-    return response.match.split(',').map((m) => {
+    return response.match.split(',').filter(m => m).map((m) => {
       const choice = choices.find(c => c.value === m);
       return choice && choice.guid;
     }).filter(s => s);

--- a/src/editors/content/question/CheckAllThatApply.tsx
+++ b/src/editors/content/question/CheckAllThatApply.tsx
@@ -190,7 +190,8 @@ export class CheckAllThatApply extends Question<CheckAllThatApplyProps, CheckAll
         responses: updatedPartModel.responses.set(
           response.guid,
           response.with({
-            match: response.match.split(',').concat([choice.value]).join(','),
+            match: response.match.split(',').filter(m => m)
+              .concat([choice.value]).join(','),
           })
           // set response score to 1 if score is less than 1
           .with({ score: +response.score < 1 ? '1' : response.score }),


### PR DESCRIPTION
This issue was caused when a user unselects all choices and then selects one. It was due to a logic error where matches were being concatenated onto a match list, then joined by ',' . This issue was, if no items are selected then the list is an empty string "" which when concatenated and joined with a match e.g. "A", it would result in array ["", ","] then finally the joined string => ",A". filtering out falsy values (i.e. empty strings) before performing this operation fixe the issue. Doing the same filtering when initially parsing the match string fixes previously affected questions as well.

**Risk**: Low, small code change. Only affects Check all that Apply questions
**Stability**: Stable, tested on new questions and existing questions that already have been affected