### PR TITLE
V0.14.0 - Fixes the issue with org editMode remaining locked after closing modal

### DIFF
--- a/src/editors/document/org/OrgEditor.tsx
+++ b/src/editors/document/org/OrgEditor.tsx
@@ -213,7 +213,9 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
     this.props.onEditingEnable(false, this.props.context.documentId);
     const delay = () =>
       command.execute(this.props.model, model, this.props.context, this.props.services)
-        .then(org => this.handleEdit(org)).then(reEnable, reEnable);
+        .then(org => this.handleEdit(org))
+        .then(reEnable)
+        .catch(reEnable);
 
     setImmediate(delay);
   }

--- a/src/editors/document/org/commands/existing/assessment.tsx
+++ b/src/editors/document/org/commands/existing/assessment.tsx
@@ -9,7 +9,7 @@ import { LegacyTypes } from 'data/types';
 
 export class AddExistingAssessmentCommand extends AbstractCommand {
 
-  onInsert(org, parent, context, services, resolve, reject, assessment: Resource) {
+  onInsert(org, parent, services, resolve, assessment: Resource) {
 
     services.dismissModal();
 
@@ -20,8 +20,9 @@ export class AddExistingAssessmentCommand extends AbstractCommand {
     resolve(insertNode(org, parent.guid, item, parent.children.size));
   }
 
-  onCancel(services) {
+  onCancel(services, reject) {
     services.dismissModal();
+    reject();
   }
 
   description() : string {
@@ -42,8 +43,8 @@ export class AddExistingAssessmentCommand extends AbstractCommand {
         <ResourceSelection
           filterPredicate={predicate}
           courseId={context.courseId}
-          onInsert={this.onInsert.bind(this, org, parent, context, services, resolve, reject)}
-          onCancel={this.onCancel.bind(this, services)}/>);
+          onInsert={assessment => this.onInsert(org, parent, services, resolve, assessment)}
+          onCancel={() => this.onCancel(services, reject)}/>);
     });
   }
 }

--- a/src/editors/document/org/commands/existing/workbookpage.tsx
+++ b/src/editors/document/org/commands/existing/workbookpage.tsx
@@ -13,7 +13,7 @@ import { Resource, ResourceState } from 'data/content/resource';
 
 export class AddExistingWorkbookPageCommand extends AbstractCommand {
 
-  onInsert(org, parent, context, services, resolve, reject, page: Resource) {
+  onInsert(org, parent, context, services, resolve, page: Resource) {
 
     services.dismissModal();
 
@@ -27,8 +27,9 @@ export class AddExistingWorkbookPageCommand extends AbstractCommand {
     resolve(insertNode(org, parent.guid, item, parent.children.size));
   }
 
-  onCancel(services) {
+  onCancel(services, reject) {
     services.dismissModal();
+    reject();
   }
 
   description() : string {
@@ -65,8 +66,8 @@ export class AddExistingWorkbookPageCommand extends AbstractCommand {
           <ResourceSelection
             filterPredicate={predicate}
             courseId={context.courseId}
-            onInsert={this.onInsert.bind(this, org, parent, context, services, resolve, reject)}
-            onCancel={this.onCancel.bind(this, services)}/>);
+            onInsert={page => this.onInsert(org, parent, context, services, resolve, page)}
+            onCancel={() => this.onCancel(services, reject)}/>);
       });
     }
 

--- a/src/utils/selection/ModalSelection.tsx
+++ b/src/utils/selection/ModalSelection.tsx
@@ -44,7 +44,10 @@ class ModalSelection extends React.PureComponent<ModalSelectionProps, {}> {
           <div className="modal-content">
             <div className="modal-header">
               <h5 className="modal-title">{this.props.title}</h5>
-              <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+              <button
+                type="button"
+                className="close"
+                onClick={this.onCancel}>
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>


### PR DESCRIPTION
Fixes an issue where modal close button doesn't call onCancel. Also fixes a bigger issue where closing a modal using the X doesn't call onCancel. Before there were 3 code paths: 1) A user completes some action. 2) A user cancels some action. 3) A user closes the modal but doesn't actually provide anyway for the caller to clean up. This fixes this a keeps the modal to only 2 codepaths.

**Risk**: Medium, this change affects all selection modals
**Stability:** Tested and appears to be be stable