### PR TITLE
change auto generated responses to include choices in name

### DIFF
--- a/src/editors/content/part/defaultFeedbackGenerator.ts
+++ b/src/editors/content/part/defaultFeedbackGenerator.ts
@@ -65,7 +65,7 @@ export const modelWithDefaultFeedback =
 
       generatedResponses = [
         new contentTypes.Response({
-          name: 'AUTOGEN',
+          name: 'AUTOGEN_*',
           score,
           match: '*',
           feedback: feedbacks.set(feedback.guid, feedback),
@@ -112,7 +112,7 @@ export const modelWithDefaultFeedback =
             .join(',');
 
           return new contentTypes.Response({
-            name: 'AUTOGEN',
+            name: `AUTOGEN_{${match}}`,
             score,
             match,
             feedback: feedbacks.set(feedback.guid, feedback),


### PR DESCRIPTION
Fixes an issue where auto generated selections are not distinct in the learning dashboard.

**Risk**: Low, only affects auto generated response names
**Stability**: Tested in the editor and content service and is stable