### PR TITLE
V0.15.0 - Fix Feedback / Explanation Migration Errors

### DIFF
--- a/src/data/content/assessment/part.ts
+++ b/src/data/content/assessment/part.ts
@@ -170,7 +170,12 @@ export class Part extends Immutable.Record(defaultPartParams) {
     return model;
   }
 
-  toPersistence(): Object {
+  toPersistence(config = { } as { saveExplanationToFeedback: boolean}):
+    Object {
+
+    // Short answers and essays in formative assessments show both the feedback and the
+    // explanation to the student, so we need to keep them in sync
+    const { saveExplanationToFeedback } = config;
 
     const children = [
 
@@ -188,7 +193,9 @@ export class Part extends Immutable.Record(defaultPartParams) {
         // filter out responses with empty matches
         .filter(r => r.match !== '')
         .toArray()
-        .map(response => response.toPersistence()),
+        .map(response => saveExplanationToFeedback
+          ? response.toPersistence({ explanation: this.explanation })
+          : response.toPersistence()),
 
       ...this.responseMult
         .toArray()

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,3 @@
+export function pipe(...args) {
+  return input => args.reduce((acc, f) => f(acc), input);
+}


### PR DESCRIPTION
Migrating feedback to explanation turned out to be more complicated than we expected. The issue is that for short answers in formative assessments, both the feedback and the explanation are shown to the student, so our premise that we could ignore feedback and migrate all of the content to explanation was wrong.

I had to write code to handle three cases:
1. The questions where we originally mapped explanation to feedback
2. The questions where we changed to incorrectly mapping explanation to feedback 
3. New questions where we are able to save explanation and feedback at the same time in `toPersistence`

Essentially, what I'm doing is if feedback has content and explanation doesn't, copy the content over from feedback to explanation. If the explanation has content and feedback doesn't, copy it over to feedback. And on all new changes, save the explanation (which is the only field exposed in the editor) to both the explanation and the feedback.

**Risk**: medium
**Stability**: stable
Test plan:
- Create a new formative assessment with a short answer or essay question
- Add an explanation and make sure the json sent has both explanation and feedback under the question's 'part'
- Edit the raw json to delete the explanation, then make a change in the editor and make sure both the explanation and feedback are populated again
- Same for the other direction (feedback to explanation)
- Create a summative assessment and make sure editing the explanation works. The migration should be handled by the previous test cases
