### PR TITLE
disable importing courses link, fix highlighting, unsupported style

### DIFF
--- a/src/components/CoursesViewSearchable.scss
+++ b/src/components/CoursesViewSearchable.scss
@@ -14,4 +14,10 @@
   .my-course-packages {
     margin: 2rem;
   }
+
+  .searchMatch {
+    border-radius: 2px;
+    background-color: #FFFF66;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 1px 1px rgba(0, 0, 0, 0.24);
+  }
 }

--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -8,7 +8,7 @@ import { SortDirection, SortableTable } from './common/SortableTable';
 import SearchBar from 'components/common/SearchBar';
 import './CoursesViewSearchable.scss';
 import { LoadingSpinner } from 'components/common/LoadingSpinner';
-import { highlightMatches } from 'components/common/SearchBarLogic';
+import { highlightMatchesStr } from 'components/common/SearchBarLogic';
 import { adjustForSkew, compareDates, relativeToNow } from 'utils/date';
 import { safeCompare } from 'components/ResourceView';
 
@@ -225,21 +225,25 @@ const CoursesViewSearchableTable = ({ rows, onSelect, searchText, serverTimeSkew
   ];
 
   const link = course => span =>
-      <button onClick={() => onSelect(course.guid)}
+      <button disabled={course.buildStatus !== 'READY'}
+        onClick={() => onSelect(course.guid)}
         className="btn btn-link">{span}</button>;
 
   const columnRenderers = [
-    r => link(r)(highlightedColumnRenderer('title', r)),
+    r => link(r)(highlightedColumnRenderer(
+      'title', r, r.buildStatus === 'READY' ? '' : ' (processing)')),
     r => highlightedColumnRenderer('version', r),
     r => highlightedColumnRenderer('id', r),
     r => <span>{relativeToNow(
       adjustForSkew(r.dateCreated, serverTimeSkewInMs))}</span>,
   ];
 
-  const highlightedColumnRenderer = (prop: string, r: CourseDescription) =>
+  const highlightedColumnRenderer = (
+    prop: string,
+    r: CourseDescription, appendText : string = '') =>
     searchText.length < 3
-      ? <span>{r[prop]}</span>
-      : highlightMatches(prop, r, searchText);
+      ? <span>{r[prop] + appendText}</span>
+      : highlightMatchesStr(r[prop] + appendText, searchText);
 
   const comparators = [
     (direction, a, b) => safeCompare('title', 'id', direction, a, b),

--- a/src/components/ResourceView.scss
+++ b/src/components/ResourceView.scss
@@ -14,6 +14,12 @@
   .document {
     padding-top: 30px;
   }
+
+  .searchMatch {
+    border-radius: 2px;
+    background-color: #FFFF66;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 1px 1px rgba(0, 0, 0, 0.24);
+  }
 }
 
 .inlineSearch {

--- a/src/components/common/SearchBarLogic.tsx
+++ b/src/components/common/SearchBarLogic.tsx
@@ -11,6 +11,11 @@ type RowData= Resource | CourseDescription;
 
 export const highlightMatches = (prop: string, r: RowData, searchText): JSX.Element => {
   const textToSearchIn = r[prop];
+  return highlightMatchesStr(textToSearchIn, searchText);
+};
+
+
+export const highlightMatchesStr = (textToSearchIn: string, searchText): JSX.Element => {
   const lowercasedTextToSearchIn = textToSearchIn.trim().toLowerCase();
   const key = searchText + '|' + lowercasedTextToSearchIn;
   const divWith = value => <div dangerouslySetInnerHTML={ { __html: value } } />;

--- a/src/editors/content/learning/Unsupported.scss
+++ b/src/editors/content/learning/Unsupported.scss
@@ -1,6 +1,5 @@
 .Unsupported-style {
-  font-family: "Inconsolata, monospace";
-	font-size: 14px;
+  font-size: 14px;
 	font-style: normal;
 	font-variant: normal;
 	font-weight: 400;


### PR DESCRIPTION
This PR addresses four things:

1) Disables links on the course package view when a course package is not in the "READY" state. 
2) Appends an " (processing)" message to non-ready course package titles
3) Restores the highlighting in course package view and resource view 
4) Restores the font in the unsupported editor back to a more readable font. I believe the font changed (negatively) during a style refactoring. 

Risk: Low, isolated, targeted changes that predominately affect UI
Stability: High, tested locally and it works