### PR TITLE
Create New Package Version from Editor

### DIFF
--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -20,6 +20,7 @@ export type CourseModelParams = {
   type?: string,
   description?: string,
   buildStatus?: string,
+  svnLocation?: string,
   deploymentStatus?: DeploymentStatus,
   dateCreated?: Date,
   metadata?: contentTypes.MetaData,
@@ -42,6 +43,7 @@ const defaultCourseModel = {
   title: '',
   description: '',
   buildStatus: '',
+  svnLocation: '',
   deploymentStatus: DeploymentStatus.DEVELOPMENT,
   dateCreated: Date.now(),
   metadata: new contentTypes.MetaData(),
@@ -86,6 +88,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
   type: string;
   description: string;
   buildStatus: string;
+  svnLocation: string;
   deploymentStatus: DeploymentStatus;
   dateCreated: Date;
   metadata: contentTypes.MetaData;
@@ -145,6 +148,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
       type: c.type,
       description: c.description,
       buildStatus: c.buildStatus,
+      svnLocation: c.svnLocation,
       deploymentStatus: c.deploymentStatus,
       dateCreated: parseDate(c.dateCreated),
       options: JSON.stringify(c.options),

--- a/src/data/persistence.ts
+++ b/src/data/persistence.ts
@@ -13,6 +13,7 @@ export {
   deleteCoursePackage,
   importPackage,
   transitionDeploymentStatus,
+  createNewVersion,
 } from './persistence/package';
 
 export {

--- a/src/data/persistence/package.ts
+++ b/src/data/persistence/package.ts
@@ -94,18 +94,27 @@ export function setCourseTheme(course: string, theme: string): Promise<{}> {
   return authenticatedFetch({ url, method, body });
 }
 
-export enum ProductionRedeploy {
+export enum Redeploy {
   Redeploy = 'REDEPLOY',
   Update = 'UPDATE',
 }
 
 export function transitionDeploymentStatus(
-  course: string, status: DeploymentStatus, redeploy?: ProductionRedeploy):
+  course: string, status: DeploymentStatus, redeploy?: Redeploy):
   Promise<{}> {
   // tslint:disable-next-line:max-line-length
   const url = `${configuration.baseUrl}/packages/${course}/status/${status}${redeploy ? `?redeploy=${redeploy}` : ''}`;
   const method = 'PUT';
   const body = JSON.stringify(status);
+
+  return authenticatedFetch({ url, method, body });
+}
+
+export function createNewVersion(course: string, version: string): Promise<{}> {
+  const url = `${configuration.baseUrl}/packages/${course}/new/version`;
+  const method = 'POST';
+
+  const body = JSON.stringify({ version });
 
   return authenticatedFetch({ url, method, body });
 }

--- a/src/editors/content/common/TextInput.tsx
+++ b/src/editors/content/common/TextInput.tsx
@@ -7,6 +7,7 @@ export interface TextInputProps {
   value: string;
   type: string;
   onEdit: (value: string) => void;
+  hasError?: boolean;
 }
 
 export interface TextInputState {
@@ -32,7 +33,7 @@ export class TextInput extends React.PureComponent<TextInputProps, TextInputStat
   }
 
   onChange(e) {
-    const { onEdit, hasError } = this.props;
+    const { onEdit } = this.props;
 
     this.caret = e.target.selectionStart;
     const value = e.target.value;
@@ -47,7 +48,7 @@ export class TextInput extends React.PureComponent<TextInputProps, TextInputStat
         style={{ width: this.props.width }}
         placeholder={this.props.label}
         onChange={this.onChange}
-        className={`form-control form-control-sm ${hasError ? '' : ''}`}
+        className={`form-control form-control-sm ${this.props.hasError ? 'is-invalid' : ''}`}
         type={this.props.type}
         value={this.props.value} />
     );

--- a/src/editors/document/course/CourseEditor.scss
+++ b/src/editors/document/course/CourseEditor.scss
@@ -13,6 +13,10 @@
         padding-bottom: 20px;
     }
 
+    hr {
+        margin: 0;
+    }
+
     .btn {
         vertical-align: unset;
         padding: 0;


### PR DESCRIPTION
* Add SVN location to CourseEditor page
* Add ability to create a new course version from the CourseEditor page
* Handle semantic versioning syntax validation for new version
* Remove "request redeploy" action button for production courses after discussion with Raphael (this is too dangerous of an action for users to request from the editor)
* Move unique ID and SVN location to bottom of CourseEditor

Risk: low, calling 1 new endpoint and removing a call to 1 other endpoint
Stability: stable, I added logic to prevent calling the "new package version" endpoint with an invalid version but this check is also handled on the backend