### PR TITLE
Add new "request deployment" endpoint, refactor CourseEditor, style changes

### DIFF
--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -4,11 +4,19 @@ import { isNullOrUndefined } from 'util';
 import { LegacyTypes } from '../types';
 import { parseDate } from 'data/content/resource';
 
+// Must match DeployStage enum values in ContentService
+export enum DeployStage {
+  qa = 'qa',
+  prod = 'prod',
+}
+
+// Must match DeploymentStatus enum values in ContentService and Admin app
 export enum DeploymentStatus {
-  DEVELOPMENT = 'DEVELOPMENT',
+  Development = 'DEVELOPMENT',
+  RequestingQA = 'REQUESTING_QA',
   QA = 'QA',
-  PRODUCTION = 'PRODUCTION',
-  REQUESTING_PRODUCTION = 'REQUESTING_PRODUCTION',
+  Production = 'PRODUCTION',
+  RequestingProduction = 'REQUESTING_PRODUCTION',
 }
 
 export type CourseModelParams = {
@@ -46,7 +54,7 @@ const defaultCourseModel = {
   description: '',
   buildStatus: '',
   svnLocation: '',
-  deploymentStatus: DeploymentStatus.DEVELOPMENT,
+  deploymentStatus: DeploymentStatus.Development,
   dateCreated: Date.now(),
   metadata: new contentTypes.MetaData(),
   options: '',

--- a/src/data/persistence.ts
+++ b/src/data/persistence.ts
@@ -12,7 +12,7 @@ export {
   retrieveCoursePackage,
   deleteCoursePackage,
   importPackage,
-  transitionDeploymentStatus,
+  requestDeployment,
   createNewVersion,
 } from './persistence/package';
 

--- a/src/data/persistence/package.ts
+++ b/src/data/persistence/package.ts
@@ -3,7 +3,7 @@ import { configuration } from '../../actions/utils/config';
 import { CourseId } from '../types';
 import * as models from '../models';
 import { Resource } from '../content/resource';
-import { DeploymentStatus } from 'data/models/course.ts';
+import { DeployStage } from 'data/models/course.ts';
 
 export function importPackage(repositoryUrl: string): void {
 
@@ -94,18 +94,11 @@ export function setCourseTheme(course: string, theme: string): Promise<{}> {
   return authenticatedFetch({ url, method, body });
 }
 
-export enum Redeploy {
-  Redeploy = 'REDEPLOY',
-  Update = 'UPDATE',
-}
-
-export function transitionDeploymentStatus(
-  course: string, status: DeploymentStatus, redeploy?: Redeploy):
+export function requestDeployment(course: string, stage: DeployStage, redeploy: boolean):
   Promise<{}> {
-  // tslint:disable-next-line:max-line-length
-  const url = `${configuration.baseUrl}/packages/${course}/status/${status}${redeploy ? `?redeploy=${redeploy}` : ''}`;
-  const method = 'PUT';
-  const body = JSON.stringify(status);
+  const url = `${configuration.baseUrl}/packages/${course}/deploy`;
+  const method = 'POST';
+  const body = JSON.stringify({ stage, redeploy });
 
   return authenticatedFetch({ url, method, body });
 }

--- a/src/editors/document/course/CourseEditor.scss
+++ b/src/editors/document/course/CourseEditor.scss
@@ -7,6 +7,18 @@
     padding: 30px 15px 0 15px;
     margin: 0 20px;
 
+    .fa.fa-circle-o-notch.fa-spin.fa-1x.fa-fw {
+        color: gray();
+    }
+
+    .fa.fa-check-circle {
+        color: $emerald;
+    }
+
+    .fa.fa-times-circle {
+        color: $alizarin;
+    }
+
     h2 {
         font-size: 20px;
         font-family: $serif-font;
@@ -19,13 +31,7 @@
 
     .btn {
         vertical-align: unset;
-        padding: 0;
-        padding-right: 10px;
-
-        &.btn-outline-primary,
-        &.btn-outline-danger {
-            padding-left: 10px;
-        }
+        padding: 0 10px;
 
         &.btn-sm {
             height: 24px;
@@ -35,12 +41,8 @@
             max-width: 150px;
         }
 
-        &.updateButton,
-        &.redeployButton,
-        &.requestQAButton,
-        &.requestProductionButton {
+        &.actionButton {
             display: inline-block;
-            max-width: 150px;
         }
     }
 
@@ -66,7 +68,6 @@
                 background-color: white;
 
                 .btn-primary {
-                    padding-left: 15px;
                     color: white;
                 }
             }


### PR DESCRIPTION
The main change here is swapping out the old "request deployment status transition" endpoint for the new "request deployment" endpoint. All of the content-service changes are on SPRINT-0.17.0, so you don't need to pull down a separate branch to test.

I also completely refactored the CourseEditor page now that the design is finalized.

Risk: low, isolated to CourseEditor page -- actions that can be taken by user are non-destructive
Stability: stable, I introduced a new RequestButton component to identify what status the request is in (which I used with the preview and create new version buttons, and all the deployment actions).