### PR TITLE
change impl to use visibility endpoint

### DIFF
--- a/src/data/persistence/package.ts
+++ b/src/data/persistence/package.ts
@@ -37,10 +37,12 @@ export function retrieveCoursePackage(courseId: CourseId): Promise<Document> {
 
 export function deleteCoursePackage(courseId: CourseId): Promise<string> {
 
-  const url = `${configuration.baseUrl}/packages/${courseId}?remove_src=false`;
-  const method = 'DELETE';
+  const url = `${configuration.baseUrl}/packages/set/visible?visible=false`;
+  const method = 'POST';
 
-  return authenticatedFetch({ url, method })
+  const body = JSON.stringify([courseId]);
+
+  return authenticatedFetch({ url, method, body })
     .then((json: any) => json.message);
 }
 


### PR DESCRIPTION
This feature got broken when we disabled the deep deletion of course packages in the content service. Deep deletions can no longer be allowed since we now support tracking resource revisions across multiple course package versions. After discussing with @rgachuhi  we decided to fix this by simply changing the front-end deletion implementation to use mark the course package as being no longer visible. 

Risk: Low, isolated to just the course package delete front-end impl
Stability: High, tested and it now allows (at least from the end user's perspective) a course package deletion