### PR TITLE
Authoring 1572 units

### DIFF
--- a/src/editors/document/org/OrgEditor.controller.ts
+++ b/src/editors/document/org/OrgEditor.controller.ts
@@ -6,6 +6,7 @@ import { AppContext } from 'editors/common/AppContext';
 import { undo, redo, documentEditingEnable } from 'actions/document';
 import { dismissSpecificMessage, showMessage } from 'actions/messages';
 import * as Messages from 'types/messages';
+import { modalActions } from 'actions/modal';
 
 interface StateProps {
   canUndo: boolean;
@@ -16,6 +17,8 @@ interface StateProps {
 interface DispatchProps {
   showMessage: (message: Messages.Message) => void;
   dismissMessage: (message: Messages.Message) => void;
+  dismissModal: () => void;
+  displayModal: (c) => void;
   onUndo: (documentId: string) => void;
   onRedo: (documentId: string) => void;
   onEditingEnable: (editable: boolean, documentId: string) => void;
@@ -40,6 +43,12 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
     },
     dismissMessage: (message: Messages.Message) => {
       dispatch(dismissSpecificMessage(message));
+    },
+    dismissModal: () => {
+      return dispatch(modalActions.dismiss());
+    },
+    displayModal: (c) => {
+      dispatch(modalActions.display(c));
     },
     onUndo: (documentId: string) =>
       dispatch(undo(documentId)),

--- a/src/editors/document/org/OrgEditor.tsx
+++ b/src/editors/document/org/OrgEditor.tsx
@@ -21,6 +21,8 @@ import { Details } from 'editors/document/org/Details';
 import { LabelsEditor } from 'editors/content/org/LabelsEditor';
 import { Title } from 'types/course';
 import { duplicateOrganization } from 'actions/models';
+import { containsUnitsOnly } from './utils';
+import { ModalMessage } from 'utils/ModalMessage';
 import * as Messages from 'types/messages';
 
 import './OrgEditor.scss';
@@ -30,6 +32,39 @@ function isNumberedNodeType(node: any) {
     || node.contentType === contentTypes.OrganizationContentTypes.Module
     || node.contentType === contentTypes.OrganizationContentTypes.Section
     || node.contentType === contentTypes.OrganizationContentTypes.Sequence);
+}
+
+const moreInfoText = 'Organizations that do not contain any modules will not display relevant'
+  + ' information in the OLI Learning Dashboard.  Therefore it is recommended that a one-level'
+  + ' organization use modules instead of units to organize course material.';
+
+function buildMoreInfoAction(display, dismiss) {
+  const moreInfoAction = {
+    label: 'More Info',
+    execute: (message: Messages.Message, dispatch) => {
+      display(
+        <ModalMessage onCancel={dismiss}>{moreInfoText}</ModalMessage>);
+    },
+  };
+  return moreInfoAction;
+}
+
+const content = new Messages.TitledContent().with({
+  title: 'No modules.',
+  message: 'Organizations without modules have learning dashboard limitations in OLI',
+});
+
+function buildUnitsMessage(display, dismiss) {
+
+  return new Messages.Message().with({
+    content,
+    guid: 'UnitsOnly',
+    scope: Messages.Scope.Resource,
+    severity: Messages.Severity.Warning,
+    canUserDismiss: false,
+    actions: Immutable.List([buildMoreInfoAction(display, dismiss)]),
+  });
+
 }
 
 function calculatePositionsAtLevel(
@@ -116,6 +151,8 @@ export interface OrgEditorProps extends AbstractEditorProps<models.OrganizationM
   onUpdateTitle: (title: Title) => void;
   showMessage: (message: Messages.Message) => void;
   dismissMessage: (message: Messages.Message) => void;
+  dismissModal: () => void;
+  displayModal: (c) => void;
   canUndo: boolean;
   canRedo: boolean;
   onUndo: (documentId: string) => void;
@@ -139,6 +176,8 @@ interface OrgEditorState extends AbstractEditorState {
 class OrgEditor extends AbstractEditor<models.OrganizationModel,
   OrgEditorProps,
   OrgEditorState>  {
+
+  unitsMessageDisplayed: boolean;
   pendingHighlightedNodes: Immutable.Set<string>;
   positionsAtLevel: Object;
   allNodeIds: string[];
@@ -151,6 +190,7 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
       highlightedNodes: Immutable.Set<string>(),
     } as OrgEditorState));
 
+    this.unitsMessageDisplayed = false;
     this.onLabelsEdit = this.onLabelsEdit.bind(this);
     this.onNodeEdit = this.onNodeEdit.bind(this);
     this.onAddSequence = this.onAddSequence.bind(this);
@@ -168,6 +208,22 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
 
     if (hasMissingResource(props.model, props.context.courseModel)) {
       props.services.refreshCourse(props.context.courseId);
+    }
+
+    this.updateUnitsMessage(props);
+  }
+
+  updateUnitsMessage(props: OrgEditorProps) {
+
+    const containsOnly = containsUnitsOnly(props.model);
+
+    if (this.unitsMessageDisplayed && !containsOnly) {
+      this.unitsMessageDisplayed = false;
+      props.dismissMessage(buildUnitsMessage(props.displayModal, props.dismissModal));
+
+    } else if (!this.unitsMessageDisplayed && containsOnly) {
+      this.unitsMessageDisplayed = true;
+      props.showMessage(buildUnitsMessage(props.displayModal, props.dismissModal));
     }
   }
 
@@ -225,6 +281,9 @@ class OrgEditor extends AbstractEditor<models.OrganizationModel,
   componentWillReceiveProps(nextProps) {
 
     if (this.props.model !== nextProps.model) {
+
+      this.updateUnitsMessage(nextProps);
+
       // Recalculate the position of the nodes ad each level. Doing this here
       // avoids having to do this on ever render.
 

--- a/src/editors/document/org/utils.ts
+++ b/src/editors/document/org/utils.ts
@@ -4,10 +4,9 @@ import * as models from '../../../data/models';
 
 import * as contentTypes from '../../../data/contentTypes';
 
-
 export function canHandleDrop(
   id: string, sourceModel, parentModel,
-  originalIndex, newIndex, newParentModel) : boolean {
+  originalIndex, newIndex, newParentModel): boolean {
 
   let accepts = false;
 
@@ -22,7 +21,7 @@ export function canHandleDrop(
     } else if (sourceModel.contentType === contentTypes.OrganizationContentTypes.Module) {
       accepts = !newParentModel.children.toArray().some(
         child => child.contentType === contentTypes.OrganizationContentTypes.Unit);
-    } else if  (sourceModel.contentType === contentTypes.OrganizationContentTypes.Include) {
+    } else if (sourceModel.contentType === contentTypes.OrganizationContentTypes.Include) {
       accepts = true;
     }
 
@@ -68,16 +67,16 @@ export function canHandleDrop(
 }
 
 export function removeNode(
-  model : models.OrganizationModel,
-  nodeGuid: string) : models.OrganizationModel {
+  model: models.OrganizationModel,
+  nodeGuid: string): models.OrganizationModel {
 
   const sequences = model.sequences.children;
   const filtered = filterChildren(nodeGuid, sequences) as any;
 
-
   const updated = model.with(
-    { sequences: model.sequences.with(
-      { children: filtered }),
+    {
+      sequences: model.sequences.with(
+        { children: filtered }),
     });
 
   return updated;
@@ -87,32 +86,84 @@ export function insertNode(
   model: models.OrganizationModel,
   targetParentGuid: string,
   childToAdd: any,
-  index: number) : models.OrganizationModel {
+  index: number): models.OrganizationModel {
 
-  return model.with({ sequences: model.sequences.with(
-    { children: (model.sequences.children.map(
-      insertChild.bind(undefined, targetParentGuid, childToAdd, index)).toOrderedMap() as any),
-    }) });
+  return model.with({
+    sequences: model.sequences.with(
+      {
+        children: (model.sequences.children.map(
+          insertChild.bind(undefined, targetParentGuid, childToAdd, index)).toOrderedMap() as any),
+      }),
+  });
 }
 
+// Returns true if this organization contains units but no modules,
+// and at least one of the units contains an item
+export function containsUnitsOnly(model: models.OrganizationModel): boolean {
+
+  // This implementaition uses regular for-loops instead of functional
+  // maps and reduces and forEach so that it can be optimized to fail-fast.
+  let containsModule = false;
+  let unitHasItem = false;
+  const sequences = model.sequences.children.toArray();
+  for (let i = 0; i < sequences.length; i += 1) {
+
+    const sequenceItem = sequences[i];
+
+    if (sequenceItem.contentType === 'Sequence') {
+
+      const firstLevel = sequenceItem.children.toArray();
+      for (let j = 0; j < firstLevel.length; j += 1) {
+        const item = firstLevel[j];
+        if (item.contentType === 'Module') {
+          containsModule = true;
+          break;
+        } else if (item.contentType === 'Unit') {
+          const children = item.children.toArray();
+          for (let k = 0; k < children.length; k += 1) {
+            const child = children[k];
+            if (child.contentType === 'Module') {
+              containsModule = true;
+              break;
+            } else if (child.contentType === 'Item') {
+              unitHasItem = true;
+            }
+          }
+        }
+        if (containsModule) {
+          break;
+        }
+      }
+    }
+
+    if (containsModule) {
+      break;
+    }
+  }
+  return !containsModule && unitHasItem;
+}
 
 export function updateNode(
   model: models.OrganizationModel,
-  childToUpdate: any) : models.OrganizationModel {
+  childToUpdate: any): models.OrganizationModel {
 
   // If the child is a top level sequence just handle it
   // explicitly
   if (model.sequences.children.has(childToUpdate.guid)) {
-    return model.with({ sequences: model.sequences.with(
-      { children: model.sequences.children.set(childToUpdate.guid, childToUpdate) })});
+    return model.with({
+      sequences: model.sequences.with(
+        { children: model.sequences.children.set(childToUpdate.guid, childToUpdate) }),
+    });
   }
 
-  return model.with({ sequences: model.sequences.with(
-    { children: (model.sequences.children.map(
-      updateChild.bind(undefined, childToUpdate)).toOrderedMap() as any),
-    }) });
+  return model.with({
+    sequences: model.sequences.with(
+      {
+        children: (model.sequences.children.map(
+          updateChild.bind(undefined, childToUpdate)).toOrderedMap() as any),
+      }),
+  });
 }
-
 
 function updateChild(
   child: any,
@@ -126,15 +177,16 @@ function updateChild(
   // Recurse if the current node has children
   return parentNode.children !== undefined && parentNode.children.size > 0
     ? parentNode.with(
-      { children: parentNode.children.map(
-        updateChild.bind(undefined, child)).toOrderedMap() })
+      {
+        children: parentNode.children.map(
+          updateChild.bind(undefined, child)).toOrderedMap(),
+      })
     : parentNode;
 }
 
-
 function filterChildren(
   guidToRemove: string,
-  children: Immutable.OrderedMap<string, any>) : Immutable.OrderedMap<string, any> {
+  children: Immutable.OrderedMap<string, any>): Immutable.OrderedMap<string, any> {
 
   const filtered = children.filter(c => c.guid !== guidToRemove);
   const mapped = filtered
@@ -145,7 +197,6 @@ function filterChildren(
     .toOrderedMap();
 
 }
-
 
 function insertChild(
   targetParentGuid: string,
@@ -180,10 +231,9 @@ function insertChild(
   // Recurse if the current node has children
   return parentNode.children !== undefined && parentNode.children.size > 0
     ? parentNode.with(
-      { children: parentNode.children.map(
-        insertChild.bind(undefined, targetParentGuid, childToAdd, index)).toOrderedMap() })
+      {
+        children: parentNode.children.map(
+          insertChild.bind(undefined, targetParentGuid, childToAdd, index)).toOrderedMap(),
+      })
     : parentNode;
 }
-
-
-


### PR DESCRIPTION
This PR introduces a warning message in the organization editor to inform users about organizations that do not contain modules.  These types of orgs will not display any relevant information in the OLI learning dashboard.

The logic implemented here is to display the message when an org meets these two criteria:
1) It contains zero modules
2) It contains at least one unit that has an item (assessment or workbook page) in it

Risk: Low, this is isolated to just the Org editor
Stability: High, tested this and it is working well