### PR TITLE
Fix issue that prevented questions from being deleted from an assessment

### DIFF
--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -297,15 +297,12 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
       onSetCurrentPage(documentId, findPage(node).guid);
     });
 
-    let pages;
-    if (isBranching) {
-      pages = handleBranchingDeletion(documentId, model.pages, guid);
-    } else {
-      const nodes = removeNode(guid, currentPage.nodes, getChildren, setChildren);
-      pages = nodes.size > 0
+    const nodes = removeNode(guid, currentPage.nodes, getChildren, setChildren);
+    const pages = isBranching
+      ? handleBranchingDeletion(documentId, model.pages, guid)
+      : nodes.size > 0
         ? model.pages.set(currentPage.guid, currentPage.with({ nodes }))
         : model.pages.remove(currentPage.guid);
-    }
 
     this.handleEdit(model.with({ pages }));
   }


### PR DESCRIPTION
The problem was that in the case of a non-branching assessment, I wasn't updating the model with the new page after removing a node from the page. I missed this because each of the cases (branching/non-branching) were sort of mixed together in the code, so I refactored the method to make it clearer and handle each case explicitly.

To test, try deleting a question from an assessment in both branching and non-branching modes. The currentNode and currentPage should also be re-set in redux.