### PR TITLE
remove overridden shouldComponentUpdate

### DIFF
--- a/src/editors/content/learning/YouTubeEditor.tsx
+++ b/src/editors/content/learning/YouTubeEditor.tsx
@@ -42,10 +42,6 @@ export default class YouTubeEditor
     this.onControlEdit = this.onControlEdit.bind(this);
   }
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.model !== this.props.model;
-  }
-
   onSrcEdit(src: string) {
     let videoSrc;
 


### PR DESCRIPTION
This PR addresses an issue where the active item handle for captions in youtube videos was always remaining 'active' - even after the user clicks and makes another item active.

The issue was in the shouldComponentUpdate method that was present in the YouTubeEditor component.  It was ignoring changes to activeContentGuid.  This shouldComponentUpdate overrides the inherited shouldComponentUpdate (which correctly checks activeContentGuid) one for no reason, so the solution here is to just remove the override.

Risk: Low, isolated to YouTubeEditor
Stability: High, tested and it fixes the issue. 