### PR TITLE
handle node changing in pools

### DIFF
--- a/src/reducers/documents.ts
+++ b/src/reducers/documents.ts
@@ -149,7 +149,9 @@ export const documents = (
         const selectedPage = action.nodeOrPageId;
         const selectedNode = ed.currentPage.valueOr('') === selectedPage
           ? ed.currentNode
-          : Maybe.just(assessment.pages.get(selectedPage).nodes.first());
+          : assessment.modelType === 'AssessmentModel'
+            ? Maybe.just(assessment.pages.get(selectedPage).nodes.first())
+            : Maybe.nothing<contentTypes.Node>();
         return state.set(action.documentId, ed.with({
           currentNode: selectedNode,
           currentPage: Maybe.just(selectedPage),
@@ -160,10 +162,12 @@ export const documents = (
       const node = action.nodeOrPageId;
       return state.set(action.documentId, ed.with({
         currentNode: Maybe.just(action.nodeOrPageId),
-        currentPage: assessment.pages.reduce(
-          (activePage, page: contentTypes.Page) =>
-            page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
-          ed.currentPage),
+        currentPage: assessment.modelType === 'AssessmentModel'
+          ? assessment.pages.reduce(
+            (activePage, page: contentTypes.Page) =>
+              page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
+            ed.currentPage)
+          : Maybe.nothing(),
       }));
     default:
       return state;


### PR DESCRIPTION
The set page and node action did not take into account that it can be dispatched from pools. This PR adjusts the logic to special case pool handling (which only has to set the node since there are no pages)

Risk: Medium - affects code used in assessment and pool editors
Stability: High - tested and works well in pools and assessments (even with pages)