### PR TITLE
upgrade react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-bootstrap-typeahead": "^2.0.2",
     "react-dnd": "2.5.4",
     "react-dnd-html5-backend": "2.5.4",
-    "react-dom": "16.2.0",
+    "react-dom": "16.2.1",
     "react-hot-loader": "^4.0.1",
     "react-jss": "^8.3.3",
     "react-redux": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,12 +36,6 @@
   version "16.0.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.28.tgz#eb0b31272528da8f20477ec27569c4f767315b33"
 
-"@types/redux-logger@^3.0.0":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-3.0.5.tgz#d1a02758f90845899cd304aa0912daeba2028eb6"
-  dependencies:
-    redux "^3.6.0"
-
 "@types/redux-thunk@^2.1.0":
   version "2.1.32"
   resolved "https://registry.yarnpkg.com/@types/redux-thunk/-/redux-thunk-2.1.32.tgz#27fac368ced9ea170bf15e5fa4a21d9201f73102"
@@ -6558,9 +6552,9 @@ react-dnd@2.5.4:
     lodash "^4.2.0"
     prop-types "^15.5.10"
 
-react-dom@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@16.2.1:
+  version "16.2.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.1.tgz#5cfb32f66267ece7b3850466bf3b219d4911fc1a"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
If we are releasing a hot fix 19.1, it'd be nice to get this in as well to remove GitHub warning and patch any security vulnerabilities 