### PR TITLE
adjust question body content constraints

### DIFF
--- a/src/data/content/assessment/types.ts
+++ b/src/data/content/assessment/types.ts
@@ -1,4 +1,4 @@
-import { FLOW_ELEMENTS, BODY_ELEMENTS } from 'data/content/common/elements';
+import { FLOW_ELEMENTS } from 'data/content/common/elements';
 
 export const ALT_FLOW_ELEMENTS = ['alternatives', ...FLOW_ELEMENTS];
 export const QUESTION_BODY_ELEMENTS = ['alternatives', 'custom', ...FLOW_ELEMENTS];


### PR DESCRIPTION
This PR fixes an issue where the body element of questions (from inline, pools, and summative) were incorrectly constrained in a way that allowed the insertion of several element types that were in fact unsupported by the DTD.  The elements include "materials" (aka Horizontal Group), "definition", "example", "pullout", "dialog", "conjugation". 

The correct characterization of question body element content is "flow.content" plus the "custom" element and "alternatives" element.  I caught a misspelling of "alternatives" and corrected that as well.

Note that the contents of the "Supporting Content" nodes is correctly characterized as "body.content" - which means the things that you can't put in question body elements you can put in supporting content.

RISK: Low
STABILITY: High, tested and it fixes the problem. You can no longer insert these elements.