### PR TITLE
Authoring 1645 full preview route broken

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -32,8 +32,11 @@ import { HelpPopover } from 'editors/common/popover/HelpPopover.controller';
 import { RouterState } from 'reducers/router';
 import { ROUTE } from 'actions/router';
 import { ResourceLoading } from 'components/ResourceLoading';
+import * as Msg from 'types/messages';
+import * as messageActions from 'actions/messages';
 
 import './Main.scss';
+import Preview from 'components/Preview';
 
 type ResourceList = {
   title: string,
@@ -229,6 +232,26 @@ export default class Main extends React.Component<MainProps, MainState> {
         return <ImportCourseView dispatch={onDispatch} />;
       case ROUTE.CREATE:
         return <CreateCourseView dispatch={onDispatch} />;
+      case ROUTE.PREVIEW: {
+        const documentId = router.resourceId;
+        const courseId = router.courseId;
+        const shouldRefresh = router.urlParams.get('refresh') === 'true';
+        const previewUrl = router.urlParams.get('url');
+        const maybePreviewUrl = previewUrl ? Maybe.nothing<string>() : Maybe.just(previewUrl);
+
+        return <Preview
+          showMessage={(message: Msg.Message) => {
+            onDispatch(messageActions.showMessage(message));
+          }}
+          dismissMessage={(message: Msg.Message) => {
+            onDispatch(messageActions.dismissSpecificMessage(message));
+          }}
+          email={this.props.user.profile.email}
+          shouldRefresh={shouldRefresh}
+          previewUrl={maybePreviewUrl}
+          documentId={documentId.valueOrThrow(new Error('document id must be defined for preview'))}
+          courseId={courseId.valueOrThrow(new Error('course id must be defined for preview'))} />;
+      }
       case ROUTE.ROOT:
         return <CoursesViewSearchable
           serverTimeSkewInMs={this.props.server.timeSkewInMs}

--- a/src/actions/router.ts
+++ b/src/actions/router.ts
@@ -10,6 +10,7 @@ export enum ROUTE {
   RESOURCE = 'resource',
   CREATE = 'create',
   IMPORT = 'import',
+  PREVIEW = 'preview',
   SKILLS = 'skills',
   PAGES = 'pages',
   FORMATIVE = 'formative',
@@ -121,6 +122,13 @@ export const getRouteFromPath = (path: string, search: string) => {
           ...parseCourseResourceIds(path),
         };
       default:
+        if (path.startsWith('preview')) {
+          return {
+            route: ROUTE.PREVIEW,
+            ...parseCourseResourceIds(path.replace(/^preview/, '')),
+          };
+        }
+
         return {
           route: ROUTE.RESOURCE,
           ...parseCourseResourceIds(path),


### PR DESCRIPTION
This PR addresses an issue where the new routing scheme didn't process preview correctly. Full course preview should now work as expected with this fix.

**Risk**: Medium, changes to routing functionality
**Stability**: Tested and is stable