### PR TITLE
do not include current page in list of available pages

### DIFF
--- a/src/editors/content/learning/XrefEditor.tsx
+++ b/src/editors/content/learning/XrefEditor.tsx
@@ -10,7 +10,7 @@ import { LegacyTypes } from 'data/types';
 import { ToolbarGroup } from 'components/toolbar/ContextAwareToolbar';
 import { ToolbarButton, ToolbarButtonSize } from 'components/toolbar/ToolbarButton';
 import { CONTENT_COLORS, getContentIcon, insertableContentTypes } from
-'editors/content/utils/content';
+  'editors/content/utils/content';
 import { SidebarContent } from 'components/sidebar/ContextAwareSidebar.controller';
 import { SidebarGroup } from 'components/sidebar/ContextAwareSidebar';
 import { ResourceState } from 'data/content/resource';
@@ -77,9 +77,13 @@ export default class XrefEditor
     }
   }
 
+  thisId = this.props.context.courseModel.resources.get(
+    this.props.context.documentId).id;
+
   pages = this.props.context.courseModel.resources
     .toArray()
     .filter(r => r.type === LegacyTypes.workbook_page &&
+      r.id !== this.thisId &&
       r.resourceState !== ResourceState.DELETED);
 
   onChangeTarget() {
@@ -90,7 +94,7 @@ export default class XrefEditor
       // Handle contiguous text as a special case, retrieving the ID of the first paragraph
       if (item.contentType === 'ContiguousText') {
         id = (item as contentTypes.ContiguousText).getFirstReferenceId();
-      // Else, if it's a valid xref target, it must have an ID
+        // Else, if it's a valid xref target, it must have an ID
       } else if (isValidXrefTarget(item)) {
         id = (item as any).id;
       }


### PR DESCRIPTION
This PR changes the XrefEditor to not allow a user to create a Xref that points to the same page that they are on.  This isn't an ideal fix as it prevents self-referential Xrefs from being created (which some courses actually do, but until we have a more complete fix I'd recommend we take this one to mitigate users from getting a course into this state.

I'll file a follow up to capture the need to allow a self-referential pop-up link. 

RISK: Low
STABILITY: High  
