### PR TITLE
fix nodeGuid routing

### DIFF
--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -195,7 +195,7 @@ class AssessmentEditor extends AbstractEditor<models.AssessmentModel,
         model.pages.reduce(
           (acc, page) => acc.caseOf({
             just: n => Maybe.just(n),
-            nothing: () => findQuestionById(page.nodes, router.urlParams.get('nodeGuid')),
+            nothing: () => findNodeByGuid(page.nodes, router.urlParams.get('nodeGuid')),
           }),
           findNodeByGuid(model.nodes, router.urlParams.get('nodeGuid')),
         );


### PR DESCRIPTION
It turns out there's no way to route to node types that aren't questions, because they have no unique Id that is consistent across page loads. When something like Supporting Content, a guid is generated but when you reload the page/go to another browser, that guid is going to be different
There is still a copy/paste bug that will require a PR, this is the fix is to use the guid as it's supposed to so that these items can be selected, but the implication is routing to these items won't work on initial page load.

**Risk**: Low, only affects question selection in assessment editor
**Stability**: Tested and is stable