### PR TITLE
support sections

### DIFF
--- a/src/data/models/assessment.ts
+++ b/src/data/models/assessment.ts
@@ -7,7 +7,6 @@ import { assessmentTemplate } from '../activity_templates';
 import { isArray, isNullOrUndefined } from 'util';
 import { ContentElements, TEXT_ELEMENTS } from 'data/content/common/elements';
 import { splitQuestionsIntoPages } from './utils/assessment';
-import { LegacyTypes } from '../types';
 
 export type AssessmentModelParams = {
   resource?: contentTypes.Resource,


### PR DESCRIPTION
This PR adds support for handling assessment sections.  Without this change, assessments with sections would not load. 

The "support" added here is simply to recognize sections and parse the content (questions, pages, content) out of them, effectively stripping out the "section". Given how few courses and assessments actually utilize sections we believed that was an acceptable approach.

RISK: Medium, a change to the main assessment model wrapper parsing code.
STABILITY: High. I found the offending resource from the A+P course and imported it into my local environment and reproduced the error.  With this fix in place I can access and edit the assessment. 