### PR TITLE
check first() result before accessing members

### DIFF
--- a/src/editors/content/learning/dynadragdrop/HTMLTableEditor.tsx
+++ b/src/editors/content/learning/dynadragdrop/HTMLTableEditor.tsx
@@ -315,7 +315,7 @@ export class HTMLTableEditor
 
     const renderTableRow = (row: Row, index) => {
       return (
-        <tr key={row.guid} className={row.isHeader && classes.headerRow}>
+        <tr key={row.guid} className={classNames([row.isHeader && classes.headerRow])}>
           <td>
             {this.renderDropdown(
               index,
@@ -333,7 +333,8 @@ export class HTMLTableEditor
                 className={classNames([classes.cell, classes.targetCell])}
                 inputVal={inputVal}
                 selectedInitiator={selectedInitiator}
-                canToggleType={question.parts.first().responses.size > 1}
+                canToggleType={question.parts.first()
+                  && question.parts.first().responses.size > 1}
                 onToggleType={this.toggleCellType}
                 editMode={editMode}
                 onDrop={onTargetDrop}


### PR DESCRIPTION
This PR addresses an issue where a specific combination of question creations results in a page crash. The exact root cause of the issue is still unknown, however this fix  should prevent the page from crashing in the meantime. After extensive testing, there seems to be no data loss resulting from this issue, it may just be a result of several saves in progress that need to resolve themselves before the necessary data is available. Also fixes a react error related to passing a boolean value into className

**Risk**: Low, small targeted fix
**Stability**: Tested and is stable