### PR TITLE
Feedback Assessment SmokeTest Issues

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -100,7 +100,7 @@ const resources = {
     (resource: Resource) => resource.type === LegacyTypes.feedback
       && resource.resourceState !== ResourceState.DELETED,
     (courseId, title, type) => models.FeedbackModel.createNew(
-      guid(), title, 'This is a course feedback assessment'),
+      guid(), title, ''),
   ),
   pages: res(
     'Workbook Pages',

--- a/src/components/toolbar/InsertToolbar.tsx
+++ b/src/components/toolbar/InsertToolbar.tsx
@@ -607,7 +607,7 @@ export class InsertToolbar
                   />)
                 }
                 disabled={!editMode || !parentSupportsElementType('activity')}>
-                {getContentIcon(insertableContentTypes.Feedback, { width: 22 })}
+                {getContentIcon(insertableContentTypes.Activity, { width: 22 })}
                 Insert feedback assessment
                 </ToolbarButtonMenuItem>
 
@@ -616,7 +616,7 @@ export class InsertToolbar
                   const model = FeedbackModel.createNew(
                     guid(),
                     'New Feedback Assessment',
-                    'This is a course feedback assessment',
+                    '',
                   );
 
                   onCreateNew(model)
@@ -629,7 +629,7 @@ export class InsertToolbar
 
                 }}
                 disabled={!editMode || !parentSupportsElementType('activity')}>
-                {getContentIcon(insertableContentTypes.Feedback, { width: 22 })}
+                {getContentIcon(insertableContentTypes.Activity, { width: 22 })}
                 Create feedback assessment
                 </ToolbarButtonMenuItem>
 
@@ -663,7 +663,7 @@ export class InsertToolbar
                           noResourcesMessage={
                             <React.Fragment>
                               No assessments are available for this activity.
-                              <br/>
+                              <br />
                               Please create a new formative assessment or remove an existing
                               reference from this page before adding another one.
                             </React.Fragment>
@@ -684,7 +684,7 @@ export class InsertToolbar
                 disabled={!editMode || !parentSupportsElementType('multipanel')}>
                 {getContentIcon(insertableContentTypes.Multipanel, { width: 22 })}
                 {' Image hotspot activity'}
-                </ToolbarButtonMenuItem>
+              </ToolbarButtonMenuItem>
             </ToolbarWideMenu>
           </ToolbarLayout.Column>
           <ToolbarLayout.Column maxWidth="100px">

--- a/src/editors/content/learning/ActivityEditor.tsx
+++ b/src/editors/content/learning/ActivityEditor.tsx
@@ -46,6 +46,13 @@ export default class ActivityEditor
     return this.props.model !== nextProps.model;
   }
 
+  isFeedback() {
+    return this.props.model.purpose.caseOf({
+      just: p => p === contentTypes.PurposeTypes.MyResponse,
+      nothing: () => false,
+    });
+  }
+
   onPurposeEdit(purpose: string): void {
     const model = this.props.model.with({
       purpose: purpose === '' ? Maybe.nothing() : Maybe.just(purpose),
@@ -83,11 +90,6 @@ export default class ActivityEditor
       .filter(p => p.value !== contentTypes.PurposeTypes.MyResponse);
     purposeTypesWithEmpty.unshift({ value: '', label: '' });
 
-    const isFeedback = this.props.model.purpose.caseOf({
-      just: p => p === contentTypes.PurposeTypes.MyResponse,
-      nothing: () => false,
-    });
-
     const activitySelect = options => <SidebarGroup label="Assessment">
       <Select
         editMode={this.props.editMode}
@@ -97,8 +99,8 @@ export default class ActivityEditor
       </Select>
     </SidebarGroup>;
 
-    if (isFeedback) {
-      return <SidebarContent title="Activity">
+    if (this.isFeedback()) {
+      return <SidebarContent title="Feedback">
         {activitySelect(feedbacks)}
       </SidebarContent>;
     }
@@ -128,15 +130,15 @@ export default class ActivityEditor
     const { onShowSidebar } = this.props;
 
     return (
-      <ToolbarGroup label="Activity" highlightColor={CONTENT_COLORS.Activity} columns={3}>
+      <ToolbarGroup label={this.isFeedback() ? 'Feedback' : 'Activity'}
+        highlightColor={CONTENT_COLORS.Activity} columns={3}>
         <ToolbarLayout.Column>
           <ToolbarButton onClick={onShowSidebar} size={ToolbarButtonSize.Large}>
             <div><i className="fa fa-sliders" /></div>
             <div>Details</div>
           </ToolbarButton>
         </ToolbarLayout.Column>
-      </ToolbarGroup>
-    );
+      </ToolbarGroup>);
   }
 
   renderMain() {
@@ -152,12 +154,12 @@ export default class ActivityEditor
 
     return (
       <div className={classNames(['ActivityEditor', classes.activity])}>
-        <h5><i className="fa fa-check" style={iconStyle}/> {titleOrPlaceholder}</h5>
+        <h5><i className="fa fa-check" style={iconStyle} /> {titleOrPlaceholder}</h5>
         <button
           onClick={this.onClick}
           type="button"
           className="btn btn-link">
-          Edit Summative Assessment
+          Edit {this.isFeedback() ? 'Feedback' : 'Summative'} Assessment
         </button>
       </div>
     );

--- a/src/editors/document/org/TreeNode.tsx
+++ b/src/editors/document/org/TreeNode.tsx
@@ -124,8 +124,6 @@ export class TreeNode
         switch (type) {
           case LegacyTypes.assessment2:
             return <i className="fa fa-check" />;
-          case LegacyTypes.feedback:
-            return <i className="fa fa-clipboard" />;
           case LegacyTypes.workbook_page:
             return <i className="fa fa-file" />;
           default:

--- a/src/editors/document/org/commands/existing/assessment.tsx
+++ b/src/editors/document/org/commands/existing/assessment.tsx
@@ -35,7 +35,7 @@ export class AddExistingAssessmentCommand extends AbstractCommand {
     context, services): Promise<models.OrganizationModel> {
 
     const predicate = (res: Resource): boolean =>
-      res.type === LegacyTypes.assessment2 || res.type === LegacyTypes.feedback
+      res.type === LegacyTypes.assessment2
       && res.resourceState !== ResourceState.DELETED;
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
* Remove placeholder "This is a course feedback assessment" description
* Change Feedback icons to Activity icons since the feedback assessment is an instance of an Activity and must use the same editor
* Change wording from "Summative" to "Feedback" in ActivityEditor when the activity is a feedback assessment
* Prevent feedback assessments from being added directly to Organizations
