### PR TITLE
Authoring 1712 remove drag drop hotspot summ

### DIFF
--- a/src/editors/content/question/addquestion/AddQuestion.tsx
+++ b/src/editors/content/question/addquestion/AddQuestion.tsx
@@ -45,8 +45,6 @@ const SUMMATIVE_OPTIONS: AddOption[] = [
   'ShortAnswer',
   'Essay',
   'Multipart',
-  'DragAndDrop',
-  'ImageHotspot',
   'Separator',
 ];
 


### PR DESCRIPTION
Removes Drag and Drop and Image Hotspot options from Summative Assessments and Question Pools

Risk: Low
Stability: High