### PR TITLE
fix an issue with empty bibfile element

### DIFF
--- a/src/data/content/bibtek/bibliography.ts
+++ b/src/data/content/bibtek/bibliography.ts
@@ -48,6 +48,9 @@ export class Bibliography extends Immutable.Record(defaultContent) {
 
     const bib = (root as any)['bib:file'];
 
+    // handle case where bib is an empty element
+    if (Object.keys(bib).length === 0) return new Bibliography();
+
     const entries = getChildren(bib).map((item) => {
       const entry = entryFromPersistence(item, createGuid(), notify);
       return [entry.guid, entry];


### PR DESCRIPTION
This PR fixes an issue where an empty bib:file element prevents the page from loading.

**Risk**: Low, targeted fix only affects bib parsing code which was already crashing the page
**Stability**: Tested on SPRINT-023.0 branch due to new webpack setup and is stable, then applied exact targeted fix to master branch