### PR TITLE
select question or node when routing to assessment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "",
   "main": "./src/app.tsx",
   "author": "",

--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -76,6 +76,9 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
     super.componentDidMount();
 
     this.showMissingSkillsMessage();
+
+    // select the routed node
+    this.selectRoutedOrDefaultNode(this.props.router);
   }
 
   shouldComponentUpdate(


### PR DESCRIPTION
NOTICE: This is targeted to master as a hotfix, we might want to change to be a sprint fix in which case we must remove the package version bump

This PR fixes an issue where routing to an assessment with questionId or nodeId param doesn't select the corresponding node.

**Risk**: Low
**Stability**: Stable