### PR TITLE
Fix feedback choice copy paste

### DIFF
--- a/src/data/contentTypes.ts
+++ b/src/data/contentTypes.ts
@@ -31,6 +31,7 @@ export { Dl } from 'data/content/learning/dl';
 export { Dt } from 'data/content/learning/dt';
 export { Example } from 'data/content/learning/example';
 export { Extra } from 'data/content/learning/extra';
+export { FeedbackChoice } from 'data/content/feedback/feedback_choice';
 export { Figure } from 'data/content/learning/figure';
 export { Flash } from 'data/content/learning/flash';
 export { Formula } from 'data/content/learning/formula';

--- a/src/data/registrar.ts
+++ b/src/data/registrar.ts
@@ -14,6 +14,7 @@ export function registerContentTypes() {
   registerType('audio', ct.Audio.fromPersistence);
   registerType('caption', ct.Caption.fromPersistence);
   registerType('cite', ct.Cite.fromPersistence);
+  registerType('choice', ct.FeedbackChoice.fromPersistence);
   registerType('code', ct.BlockCode.fromPersistence);
   registerType('codeblock', ct.CodeBlock.fromPersistence);
   registerType('command', ct.Command.fromPersistence);


### PR DESCRIPTION
`FeedbackChoice` was not in the registry so was not detected as a valid copy/paste element.

![image](https://user-images.githubusercontent.com/16868015/54129366-766d7480-43e4-11e9-888c-012af39236d3.png)

I added the `FeedbackChoice` model under `choice` in the registry because that is the `elementType` it is persisted under in the wrapper. We are using the same `elementType` for the normal multiple choice question type, but this is not used in the registry so there is no conflict.

Risk: low
Stability: stable