### PR TITLE
adjust styling, impl canDrop logic

### DIFF
--- a/src/editors/common/tree/types/div.scss
+++ b/src/editors/common/tree/types/div.scss
@@ -22,14 +22,14 @@
 
   .top-drop {
     position: absolute;
-    top: -5px;
+    top: -6px;
     height: 10px;
     width: 100%;
   }
 
   .bottom-drop {
     position: absolute;
-    top: 35px;
+    bottom: 0px;
     height: 10px;
     width: 100%;
   }

--- a/src/editors/document/org/outline/Outline.tsx
+++ b/src/editors/document/org/outline/Outline.tsx
@@ -94,6 +94,15 @@ const canHandleDrop: Tree.CanDropHandler<OutlineNode> = (
   newParent: Maybe<OutlineNode>,
   newIndex: number): boolean => {
 
+  // Do not allow dropping immediately above or below the
+  // original node
+  if (newIndex < originalIndex) {
+    if (originalIndex - newIndex < 1) {
+      return false;
+    }
+  } else if (newIndex - originalIndex <= 1) {
+    return false;
+  }
   return true;
 };
 


### PR DESCRIPTION
This PR fixes two separate problems with the dnd UX:

1) Reposition targets immediately above and below the source node were being highlighted as "able to be dropped on".  Dropping here wouldn't actually reorder - so we need to disable these.  The root cause was that the canDrop method in the Org outline simply returned 'true'.

2) The positions of the top and bottom drop targets were off.  I adjusted them and verified they still look correct in the assessment editor as well as the OrgComponentEditor.

RISK: Low, visual changes mainly
STABILITY: High, tested and works