### PR TITLE
Make login/logout wording consistent

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -190,7 +190,7 @@ class Header extends React.PureComponent<StyledComponentProps<HeaderProps>, Head
             Help / Feedback
           </MenuItem>
           <div className="dropdown-divider"></div>
-          <MenuItem url={logoutUrl}>Logout</MenuItem>
+          <MenuItem url={logoutUrl}>Log Out</MenuItem>
         </Menu>
       </React.Fragment>
     );


### PR DESCRIPTION
The only place we use `logout/log out` in the editor is in the user dropdown, and the only place we use `login/log in` is in the keycloak login page. Almost all websites I see use "Log In" as a verb and "Login" as a noun, so we should be consistent.

Legacy OLI uses a mix of "sign out", "log out", and "logout", so it would need to be changed in several places. But we can at least do it for the editor here.

![image](https://user-images.githubusercontent.com/16868015/54386215-d8d9a580-466e-11e9-98a0-8d099e5b268f.png)
![image](https://user-images.githubusercontent.com/16868015/54386229-e000b380-466e-11e9-9a76-281eba7296fc.png)

Risk: very low
Stability: stable