### PR TITLE
Fix objectives "typeahead" -- remove custom renderer

### DIFF
--- a/src/editors/document/workbook/Objectives.tsx
+++ b/src/editors/document/workbook/Objectives.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { Typeahead, Highlighter } from 'react-bootstrap-typeahead';
+import { Typeahead } from 'react-bootstrap-typeahead';
 import * as contentTypes from 'data/contentTypes';
 import {
   AbstractContentEditor, AbstractContentEditorProps,
@@ -111,18 +111,6 @@ export class Objectives
           options={options}
           labelKey="title"
           selected={this.state.selected}
-          renderMenuItemChildren={(option, props, index) => [
-            <Highlighter key="title" search={props.text}>
-              {option.title}
-            </Highlighter>,
-            <div>
-              <small>
-                Skills: {this.props.context.objectives.get(option.id)
-                  ? this.props.context.objectives.get(option.id).skills.size
-                  : 0}
-              </small>
-            </div>,
-          ]}
         />
       </div >
     );


### PR DESCRIPTION
On shattrath, some objectives throw a runtime (frowny face) error when adding objectives to a workbook page.

This is a strange issue with the `react-bootstrap-typeahead` component. I'm not sure what the root cause is, but some objectives seem to be causing a react invariant error when the typeahead component renders them using a custom menu item renderer that I wrote. 


The `Highlighter` component throws an error below, but I'm using it exactly the way the npm package docs show, and I can't figure out why I wasn't able to trigger this error before in the original PR.
```
renderMenuItemChildren={(option, props, index) => [
            <Highlighter search={props.text}>
              {option.title}
            </Highlighter>,
            <small>
              Skills: {this.props.context.objectives.get(option.id)
                ? this.props.context.objectives.get(option.id).skills.size
                : 0}
            </small>,
          ]}
```

The purpose of the custom renderer was just to show the number of skills attached to an objective, so it's not terribly important. Since the documentation on the custom renderer is extremely sparse, I think it's easier just to remove it rather than worrying about how to fix it.

Risk: low
Stability: stable