### PR TITLE
adjust hover style

### DIFF
--- a/src/editors/content/container/ContentDecorator.styles.ts
+++ b/src/editors/content/container/ContentDecorator.styles.ts
@@ -15,14 +15,13 @@ export const styles: JSSStyles = {
     width: '100%',
   },
   hover: {
-    '& > $handle': props => ({
+    '& > $handle': {
       left: -18,
       opacity: 1,
       cursor: 'pointer',
-      borderLeft: '2px solid ' + getContentColor(props.contentType),
-
+      borderLeft: props => '2px solid ' + getContentColor(props.contentType),
       transition: 'opacity .1s ease-in',
-    }),
+    },
   },
   handle: {
     extend: [disableSelect],


### PR DESCRIPTION
This PR fixes a regression where upgrade to React 16 caused hover over content decorator to stop working.

RISK: Low
STABILITY: High, tested and works