### PR TITLE
set the canUndo canRedo flags

### DIFF
--- a/src/editors/document/org/OrgDetailsEditor.controller.ts
+++ b/src/editors/document/org/OrgDetailsEditor.controller.ts
@@ -19,6 +19,8 @@ interface StateProps {
   editMode: boolean;
   course: models.CourseModel;
   placements: org.Placements;
+  canUndo: boolean;
+  canRedo: boolean;
 }
 
 interface DispatchProps {
@@ -48,6 +50,8 @@ const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {
     course,
     editMode: course.editable,
     placements: orgs.placements,
+    canUndo: orgs.undoStack.size > 0,
+    canRedo: orgs.redoStack.size > 0,
   };
 };
 


### PR DESCRIPTION
This PR fixes undo/redo for the embedded OrgComponentEditor usage.

We weren't setting the canUndo and canRedo flags - which somehow compiled fine.  I don't understand that.   They are set properly now so the undo / redo buttons enable now when they should and work fine when used.

RISK: Low
STABILITY: High