### PR TITLE
restore entity creation, allow question editing in multiparts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "",
   "main": "./src/app.tsx",
   "author": "",

--- a/src/data/content/learning/contiguous.ts
+++ b/src/data/content/learning/contiguous.ts
@@ -358,7 +358,7 @@ export class ContiguousText extends Immutable.Record(defaultContent) {
         selectionState = new SelectionState({
           anchorKey: selectionState.getAnchorKey(),
           focusKey: selectionState.getFocusKey(),
-          anchorOffset: selectionState.getAnchorOffset,
+          anchorOffset: selectionState.getAnchorOffset(),
           focusOffset: selectionState.getAnchorOffset() + 1,
         });
       }
@@ -371,16 +371,17 @@ export class ContiguousText extends Immutable.Record(defaultContent) {
       contentState = appendText(block, contentState, '  ');
     }
 
-    const contentStateWithEntity = contentState.createEntity(type, mutability, data);
-    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-    const contentStateWithLink = Modifier.applyEntity(
+    contentState = contentState.createEntity(type, mutability, data);
+    const entityKey = contentState.getLastCreatedEntityKey();
+
+    contentState = Modifier.applyEntity(
       contentState,
       selectionState,
       entityKey,
     );
 
     return this.with({
-      content: contentStateWithLink,
+      content: contentState,
       entityEditCount: this.entityEditCount + 1,
     });
   }

--- a/src/editors/content/common/draft/decorators/InputRef.tsx
+++ b/src/editors/content/common/draft/decorators/InputRef.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { byType, Decorator } from './common';
 import { EntityTypes } from '../../../../../data/content/learning/common';
-import { connect, Dispatch } from 'react-redux';
-import { State } from 'reducers';
 
 import './InputRef.scss';
 
@@ -59,37 +57,10 @@ const InputRef = (props) => {
   );
 };
 
-interface StateProps {
-  activeItemId: string;
-}
-
-interface DispatchProps {
-
-}
-
-interface OwnProps {
-
-}
-
-const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {
-  return {
-    activeItemId: state.inputRef.valueOr(''),
-  };
-};
-
-const mapDispatchToProps = (dispatch: Dispatch<State>, ownProps: OwnProps): DispatchProps => {
-  return {
-
-  };
-};
-
-const ConnectedInputRef = connect<StateProps, DispatchProps, OwnProps>
-(mapStateToProps, mapDispatchToProps)(InputRef);
-
-export default function (props: Object) : Decorator {
+export default function (props: Object): Decorator {
   return {
     strategy: byType.bind(undefined, EntityTypes.input_ref),
-    component: ConnectedInputRef,
+    component: InputRef,
     props,
   };
 }


### PR DESCRIPTION
This PR fixes two problems related to Draft entities:
1) MathML and Cites (and other entities) could not be created due to a typo that landed in sprint 25.
2) It seems that React 16.8 upgrade has changed how Draft deals with decorators that are rendered out-of-band via a Redux connected component.  This horribly broke the ability to edit input questions.  The short-term fix here is to simply remove the Redux connection.

RISK: Low
STABILITY: High, tested and fixes. 