### PR TITLE
Authoring 1860 numeric

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "",
   "main": "./src/app.tsx",
   "author": "",


### PR DESCRIPTION
This PR fixes editing of numeric input options.

The root cause was that we hadn't upgraded in the package.json file the version of bs-platform. This meant that deployments would bundle the old bucklescript runtimes - which was causing the problem.

RISK: Low
STABILITY: High, tested on shattrath, fixes the problem. 

NOTE: the version on shattrath didn't have the package version bump, which is why it still says 0.25.2