### PR TITLE
Move organization undo/redo toolbar

### DIFF
--- a/src/editors/document/org/OrgComponentEditor.tsx
+++ b/src/editors/document/org/OrgComponentEditor.tsx
@@ -218,12 +218,18 @@ export class OrgComponentEditor
           <div className="org-component-editor">
             <div style={{ display: 'flex', flexDirection: 'row' }}>
               {titleEditor}
-              <div className="flex-spacer" />
-              <UndoRedoToolbar
-                undoEnabled={canUndo}
-                redoEnabled={canRedo}
-                onUndo={onUndo.bind(this)}
-                onRedo={onRedo.bind(this)} />
+              {model.contentType === t.OrganizationContentTypes.Unit
+                || model.contentType === t.OrganizationContentTypes.Module
+                || model.contentType === t.OrganizationContentTypes.Section
+                || model.contentType === t.OrganizationContentTypes.Sequence
+                ? <React.Fragment><div className="flex-spacer" />
+                  <UndoRedoToolbar
+                    undoEnabled={canUndo}
+                    redoEnabled={canRedo}
+                    onUndo={onUndo.bind(this)}
+                    onRedo={onRedo.bind(this)} /></React.Fragment>
+                : null
+              }
             </div>
 
             {preconditions}

--- a/src/editors/document/org/OrgDetailsEditor.scss
+++ b/src/editors/document/org/OrgDetailsEditor.scss
@@ -1,52 +1,56 @@
-@import 'oli/colors';
-@import 'oli/typography';
+@import "oli/colors";
+@import "oli/typography";
 
 .org-details-editor {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 15px;
-  height: 100%;
-
-  .btn {
-    i {
-      margin-right: 8px;
-    }
-  }
-
-  .org-tab {
-    margin-left: 40px;
-    margin-right: 40px;
-  }
-
-	.doc-head {
     flex: 1;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+    height: 100%;
 
-    .action-bar {
-      .btn {
-        padding: 5px 20px;
-        position: relative;
-        top: -6px;
+    .org-details-title {
+        display: flex;
+        justify-content: space-between;
+    }
 
-        &:hover {
-          border: 0px solid $blue;
-          color: $blue;
-          text-decoration: underline;
+    .btn {
+        i {
+            margin-right: 8px;
         }
-      }
     }
 
-    .nav-link {
-      cursor: pointer;
+    .org-tab {
+        margin-left: 40px;
+        margin-right: 40px;
     }
-  }
 
-  .tab-container {
-    .tab-header {
-      margin-top: 10px;
-      margin-bottom: 10px;
+    .doc-head {
+        flex: 1;
+        overflow: auto;
+
+        .action-bar {
+            .btn {
+                padding: 5px 20px;
+                position: relative;
+                top: -6px;
+
+                &:hover {
+                    border: 0px solid $blue;
+                    color: $blue;
+                    text-decoration: underline;
+                }
+            }
+        }
+
+        .nav-link {
+            cursor: pointer;
+        }
     }
-  }
 
+    .tab-container {
+        .tab-header {
+            margin-top: 10px;
+            margin-bottom: 10px;
+        }
+    }
 }

--- a/src/editors/document/org/OrgDetailsEditor.tsx
+++ b/src/editors/document/org/OrgDetailsEditor.tsx
@@ -15,6 +15,7 @@ import './OrgDetailsEditor.scss';
 import { containsUnitsOnly } from './utils';
 import { ModalMessage } from 'utils/ModalMessage';
 import { TabContainer, Tab } from 'components/common/TabContainer';
+import UndoRedoToolbar from 'editors/document/common/UndoRedoToolbar';
 
 function buildMoreInfoAction(display, dismiss) {
   const moreInfoText = 'Organizations that do not contain any modules will not display relevant'
@@ -233,7 +234,14 @@ export class OrgDetailsEditor
           <div className="org-details-editor">
             <div className="doc-head">
 
-              <h3>Organization: {m.title}</h3>
+              <div className="org-details-title">
+                <h3>Organization: {m.title}</h3>
+                <UndoRedoToolbar
+                  undoEnabled={this.props.canUndo}
+                  redoEnabled={this.props.canRedo}
+                  onUndo={this.props.onUndo.bind(this)}
+                  onRedo={this.props.onRedo.bind(this)} />
+              </div>
 
               {this.renderTabs(m)}
             </div>


### PR DESCRIPTION
This PR simply moves the undo/redo toolbar for organizations into a higher level component so that it can be used in any tab.
![image](https://user-images.githubusercontent.com/16868015/57026702-61ed7180-6c08-11e9-8274-b8ea318ecafb.png)

Risk: low
Stability: stable