### PR TITLE
Lowercase learning objective creation duplicate box

### DIFF
--- a/src/components/objectives/DuplicateListingInput.tsx
+++ b/src/components/objectives/DuplicateListingInput.tsx
@@ -42,11 +42,11 @@ export class DuplicateListingInput
     this.setState({ value: nextProps.value });
   }
 
-  onChange(e) {
+  onChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value;
 
     const duplicates = this.props.existing.filter(
-      v => v.toLowerCase().indexOf(value) !== -1).toList();
+      v => v.toLowerCase().indexOf(value.toLowerCase()) !== -1).toList();
     this.setState({ value, duplicates });
   }
 


### PR DESCRIPTION
This PR simply strips the casing of the learning objective creation box so that duplicates can be detected regardless of the letter case.

![image](https://user-images.githubusercontent.com/16868015/57026818-b1cc3880-6c08-11e9-83a9-2bb05c2ba787.png)

Risk: low
Stability: stable
