### PR TITLE
Authoring 1884 org delete

### DIFF
--- a/src/components/DeleteResourceModal.controller.ts
+++ b/src/components/DeleteResourceModal.controller.ts
@@ -8,6 +8,7 @@ import { ResourceState } from 'data/content/resource';
 import { updateCourseResources } from 'actions/course';
 import * as viewActions from 'actions/view';
 import { modalActions } from 'actions/modal';
+import { LegacyTypes } from 'data/types';
 
 interface StateProps {
 
@@ -42,8 +43,18 @@ const mapDispatchToProps = (dispatch: Dispatch<State>, ownProps: OwnProps): Disp
         updatedResource.guid, updatedResource,
       ]]);
       dispatch(updateCourseResources(resources));
-      dispatch(viewActions.viewAllResources(course.guid, orgId));
+
+      let orgToView = orgId;
+      if (orgToView === updatedResource.guid) {
+        orgToView = ownProps.course.resources.toArray().filter(
+          r => r.type === LegacyTypes.organization
+            && r.guid !== orgId && r.resourceState !== 'DELETED',
+        )[0].guid;
+      }
+
+      dispatch(viewActions.viewAllResources(course.guid, orgToView));
       dispatch(modalActions.dismiss());
+
     },
   };
 };

--- a/src/components/NavigationPanel.tsx
+++ b/src/components/NavigationPanel.tsx
@@ -498,6 +498,8 @@ class NavigationPanel
     const { classes, viewActions, course, router, profile, onCreateOrg } = this.props;
     const { showOrgDropdown, collapsed } = this.state;
 
+    const availableOrgs = r => r.type === 'x-oli-organization' && r.resourceState !== 'DELETED';
+
     return (
       <div className="dropdown">
         <div className={classNames([
@@ -534,7 +536,7 @@ class NavigationPanel
           </div>
         </div>
         <div className={classNames(['dropdown-menu', showOrgDropdown && 'show'])}>
-          {course.resources.valueSeq().filter(r => r.type === 'x-oli-organization').map(org => (
+          {course.resources.valueSeq().filter(availableOrgs).map(org => (
             <a key={org.guid}
               className={classNames(['dropdown-item'])}
               onClick={() => {

--- a/src/editors/document/org/OrgComponentEditor.tsx
+++ b/src/editors/document/org/OrgComponentEditor.tsx
@@ -299,14 +299,14 @@ export class OrgComponentEditor
         const processor = this.processCommand.bind(this, org, model);
 
         const removeCommand = new RemoveCommand();
-        const remove = (
+        const remove = model.contentType !== 'Sequences' ? (
           <Remove
             style={{ float: 'right' }}
             editMode={this.props.editMode && removeCommand.precondition(org, model)}
             onRemove={() => processor(removeCommand)}>
             Remove {this.getLabel(model)}
           </Remove>
-        );
+        ) : null;
         return (
           <div>
             {[

--- a/src/editors/document/org/OrgDetailsEditor.controller.ts
+++ b/src/editors/document/org/OrgDetailsEditor.controller.ts
@@ -9,7 +9,7 @@ import { Map } from 'immutable';
 import * as t from 'data/contentTypes';
 import { dismissSpecificMessage, showMessage } from 'actions/messages';
 import { modalActions } from 'actions/modal';
-import { change, undo, redo, releaseOrg } from 'actions/orgs';
+import { change, undo, redo } from 'actions/orgs';
 import { UserState } from 'reducers/user';
 
 

--- a/src/editors/document/org/OrgDetailsEditor.controller.ts
+++ b/src/editors/document/org/OrgDetailsEditor.controller.ts
@@ -9,7 +9,7 @@ import { Map } from 'immutable';
 import * as t from 'data/contentTypes';
 import { dismissSpecificMessage, showMessage } from 'actions/messages';
 import { modalActions } from 'actions/modal';
-import { change, undo, redo } from 'actions/orgs';
+import { change, undo, redo, releaseOrg } from 'actions/orgs';
 import { UserState } from 'reducers/user';
 
 


### PR DESCRIPTION
This PR improves the workflow for deleting orgs.  

1) First, it ensures that deleted orgs are not displayed in the dropdown.
2) It also displays a different org after one is deleted
3) Finally, it removes the redundant (and non-functioning) "Remove Organization" button