### PR TITLE
Show errors when the learning objective page is locked

### DIFF
--- a/src/components/WritelockModal.controller.ts
+++ b/src/components/WritelockModal.controller.ts
@@ -12,8 +12,8 @@ interface DispatchProps {
 }
 
 interface OwnProps {
-  courseId: string;
-  documentId: string;
+  courseId?: string;
+  documentId?: string;
 }
 
 const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {

--- a/src/components/WritelockModal.tsx
+++ b/src/components/WritelockModal.tsx
@@ -6,8 +6,8 @@ import { styles } from './WritelockModal.styles';
 
 export interface WritelockModalProps {
   className?: string;
-  courseId: string;
-  documentId: string;
+  courseId?: string;
+  documentId?: string;
   onLoadDocument: (courseId, documentId) => Promise<any>;
 }
 
@@ -62,9 +62,11 @@ class WritelockModal
               </div>
             </div>
             <div className="modal-footer">
-              <button type="button" className="btn btn-primary"
-                onClick={e => onLoadDocument(courseId, documentId)}
-                data-dismiss="modal">Refresh</button>
+              {courseId && documentId
+                ? <button type="button" className="btn btn-primary"
+                  onClick={e => onLoadDocument(courseId, documentId)}
+                  data-dismiss="modal">Refresh</button>
+                : null}
             </div>
           </div>
         </div>

--- a/src/components/objectives/ObjectiveSkillView.controller.ts
+++ b/src/components/objectives/ObjectiveSkillView.controller.ts
@@ -55,7 +55,6 @@ const mapStateToProps = (state: State): StateProps => {
 
 const mapDispatchToProps = (dispatch): DispatchProps => {
   return {
-
     onFetchSkills: (courseId: string) => {
       return dispatch(fetchSkills(courseId));
     },
@@ -94,6 +93,6 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 };
 
 export const controller = connect<StateProps, DispatchProps, OwnProps>
-    (mapStateToProps, mapDispatchToProps)(ObjectiveSkillView);
+  (mapStateToProps, mapDispatchToProps)(ObjectiveSkillView);
 
 export { controller as ObjectiveSkillView };

--- a/src/utils/error.tsx
+++ b/src/utils/error.tsx
@@ -38,12 +38,12 @@ export function buildConflictMessage() {
 
 }
 
-export function buildPersistenceFailureMessage(reason: string, user: UserProfile) {
+export function buildPersistenceFailureMessage(
+  reason: string, user: UserProfile, isntResource = false) {
 
   const name = user.firstName + ' ' + user.lastName;
 
   if (reason === 'Bad Request') {
-
     const content = new Messages.TitledContent().with({
       title: 'Cannot save',
       message: 'There was a problem saving your changes. Try reverting recent changes.',
@@ -51,12 +51,11 @@ export function buildPersistenceFailureMessage(reason: string, user: UserProfile
     return new Messages.Message().with({
       content,
       guid: 'PersistenceProblem',
-      scope: Messages.Scope.Resource,
+      scope: isntResource ? Messages.Scope.Application : Messages.Scope.Resource,
       severity: Messages.Severity.Error,
       canUserDismiss: false,
       actions: Immutable.List([buildReportProblemAction(reason, name, user.email)]),
     });
-
   }
 
   const content = new Messages.TitledContent().with({
@@ -66,13 +65,11 @@ export function buildPersistenceFailureMessage(reason: string, user: UserProfile
   return new Messages.Message().with({
     content,
     guid: 'UnknownError',
-    scope: Messages.Scope.Resource,
+    scope: isntResource ? Messages.Scope.Application : Messages.Scope.Resource,
     severity: Messages.Severity.Error,
     canUserDismiss: true,
     actions: Immutable.List([buildReportProblemAction(reason, name, user.email)]),
   });
-
-
 }
 
 function buildModalMessageAction(label, text): Messages.MessageAction {


### PR DESCRIPTION
Show a modal / banner when an edit cannot be performed on the learning objective page (due to write lock, timeout).

We were previously trying to show a banner when the page was locked, but it wasn't showing up because the "scope" of the banner message wasn't correct.

Risk: low
Stability: stable