### PR TITLE
Authoring 1903 reduce

### DIFF
--- a/src/components/objectives/ObjectiveSkillView.tsx
+++ b/src/components/objectives/ObjectiveSkillView.tsx
@@ -90,11 +90,13 @@ function skillToAssessmentMap(skillEdges: Edge[], isInOrg: (string) => boolean) 
 
   const skills = {};
   skillEdges.forEach((e) => {
-    if (skills[e.destinationId] === undefined) {
-      skills[e.destinationId] = [];
+
+    const id = resourceId(e.destinationId);
+    if (skills[id] === undefined) {
+      skills[id] = [];
     }
-    if (isInOrg(e.sourceId)) {
-      skills[e.destinationId].push(e);
+    if (isInOrg(resourceId(e.sourceId))) {
+      skills[id].push(e);
     }
   });
   return skills;
@@ -117,7 +119,7 @@ function reduceSkillToQuestionRefs(
     .map((skill) => {
 
       // Now for each skill, get the assessment edges
-      const edges: Edge[] = skillMap[skill.id];
+      const edges: Edge[] = skillMap[resourceId(skill.id)];
       const refs = [];
 
       // edges will be undefined if a skill simply has no assessments in

--- a/src/editors/document/org/Analytics.tsx
+++ b/src/editors/document/org/Analytics.tsx
@@ -522,7 +522,7 @@ class Analytics
     question: QuestionRef, skill: SkillRef, organization: models.OrganizationModel) {
     const { classes, course, analytics, onPushRoute } = this.props;
 
-    const parts = getOrderedParts(question.body, question.parts)
+    const parts = getOrderedParts(question.body(), question.parts())
       // get ordered index of part, because we will filter out parts without this skill
       .map((part, index) => ({
         index,
@@ -563,7 +563,7 @@ class Analytics
 
   renderQuestion(question: QuestionRef, skill: SkillRef, organization: models.OrganizationModel) {
     const { classes, course, analytics, onPushRoute } = this.props;
-
+    const parts = question.parts();
     return (
       <div key={question.key} className={classes.question}>
         <div key={question.key} className={classes.questionTitle}>
@@ -575,8 +575,8 @@ class Analytics
               + `?questionId=${question.id}`)}>
             {question.title.valueOr(getReadableTitleFromType(question.type))}
           </div>
-          {question.parts.size === 1 && (
-            Maybe.maybe(question.parts.first()).caseOf({
+          {parts.size === 1 && (
+            Maybe.maybe(parts.first()).caseOf({
               just: part => analytics.dataSet.caseOf({
                 just: analyticsDataSet => analyticsDataSet.byResourcePart.caseOf({
                   just: byResourcePart => Maybe.maybe(
@@ -593,7 +593,7 @@ class Analytics
             })
           )}
         </div>
-        {question.parts.size > 1 && this.renderMultipleParts(question, skill, organization)}
+        {parts.size > 1 && this.renderMultipleParts(question, skill, organization)}
       </div>
     );
   }

--- a/src/types/questionRef.ts
+++ b/src/types/questionRef.ts
@@ -32,8 +32,8 @@ export interface QuestionRef {
   assessmentType: LegacyTypes;
   assessmentId: string;
   poolInfo: Maybe<PoolInfo>;
-  parts: List<Part>;
-  body: ContentElements;
+  parts: () => List<Part>;
+  body: () => ContentElements;
   label: string;
 }
 
@@ -56,11 +56,11 @@ const getPoolQuestionCount = (pathItem: SkillPathElement) => {
 };
 
 const getParts = (pathItem: SkillPathElement) => pathItem.parts
-  ? List<Part>(pathItem.parts.map(p => Part.fromPersistence(p, guid(), () => {})))
+  ? List<Part>(pathItem.parts.map(p => Part.fromPersistence(p, guid(), () => { })))
   : List<Part>();
 
 const getBody = (pathItem: SkillPathElement) => pathItem['body'] && ContentElements.fromPersistence(
-  pathItem['body'], guid(), QUESTION_BODY_ELEMENTS, null, () => {});
+  pathItem['body'], guid(), QUESTION_BODY_ELEMENTS, null, () => { });
 
 export const getQuestionRefFromPathInfo = (
   pathItem: SkillPathElement, assessmentType: LegacyTypes,
@@ -77,8 +77,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'short_answer':
@@ -91,8 +91,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'fill_in_the_blank':
@@ -105,8 +105,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'image_hotspot':
@@ -119,8 +119,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'multiple_choice':
@@ -133,8 +133,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'numeric':
@@ -147,8 +147,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'ordering':
@@ -161,8 +161,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     case 'question':
@@ -175,8 +175,8 @@ export const getQuestionRefFromPathInfo = (
         assessmentType,
         assessmentId,
         poolInfo: getPoolQuestionCount(pathItem),
-        parts: getParts(pathItem),
-        body: getBody(pathItem),
+        parts: () => getParts(pathItem),
+        body: () => getBody(pathItem),
         label: pathItem.label,
       });
     default:


### PR DESCRIPTION
This PR further optimizes the rendering of the Objectives editor. It does so via two specific changes:
1. Reduce the algorithmic runtime of the reduceSkillToQuestionRefs method by calculating a mapping of skills to assessments that tag them, upfront.  This calculation was being inside a per skill loop, previously.
2. Make the parsing of body and parts of question refs "just in time" - rather than upfront.  This greatly improves the performance as neither of these are being used in this view - yet they were being calculated.

RISK: Low
STABILITY: High - a build is present on shattrath.  The  A&P course now renders in just a couple of seconds. 
