### PR TITLE
Add image filename to sidebar

### DIFF
--- a/src/editors/content/learning/ImageEditor.tsx
+++ b/src/editors/content/learning/ImageEditor.tsx
@@ -9,7 +9,7 @@ import { StyledComponentProps } from 'types/component';
 import { MediaManager } from 'editors/content/media/manager/MediaManager.controller';
 import { MIMETYPE_FILTERS, SELECTION_TYPES } from 'editors/content/media/manager/MediaManager';
 import { MediaItem } from 'types/media';
-import { adjustPath } from 'editors/content/media/utils';
+import { adjustPath, extractFileName } from 'editors/content/media/utils';
 import { SidebarContent } from 'components/sidebar/ContextAwareSidebar.controller';
 import { SidebarGroup, SidebarRow } from 'components/sidebar/ContextAwareSidebar';
 import { ToolbarGroup, ToolbarLayout } from 'components/toolbar/ContextAwareToolbar';
@@ -29,6 +29,7 @@ const IMAGE = require('../../../../assets/400x300.png');
 
 import { styles } from './MediaElement.styles';
 import { CaptionTextEditor } from './contiguoustext/CaptionTextEditor';
+import { Tooltip } from 'utils/tooltip';
 
 export interface ImageSizeSidebarProps {
   services: AppServices;
@@ -168,10 +169,25 @@ export class ImageSizeSidebar extends
 
   render() {
     const { editMode } = this.props;
-    const { width, height } = this.props.model;
+    const { width, height, src } = this.props.model;
+
+    const fileName = extractFileName(src);
+    const titleDisplay = (
+      <SidebarGroup label="Image Name">
+        <SidebarRow>
+          <Tooltip title={fileName}
+            delay={150} distance={5} size="small" arrowSize="small">
+            {fileName.length > 30
+              ? fileName.substr(0, 30) + '...'
+              : fileName}
+          </Tooltip>
+        </SidebarRow>
+      </SidebarGroup>
+    );
 
     return (
       <div>
+        {titleDisplay}
         <SidebarGroup label="">
           <ToolbarButton onClick={this.onSelect} size={ToolbarButtonSize.Large}>
             <div>{getContentIcon(insertableContentTypes.Image)}</div>


### PR DESCRIPTION
After you've uploaded an image to a resource, it's hard to know what the image name is unless you go into the media manager and try to find it, but the manager itself doesn't always properly select the active image.

This PR just adds the filename (image path) to the sidebar so you know what image you've got uploaded. I'd like to fix the issue with the media manager not always selecting the image, but after some investigation, I found that the unhappy path that causes this issue is rare - it only applies to images that were uploaded pre-editor with filenames that include non-url-encoded characters (like spaces).

Risk: very low
Stability: stable