### PR TITLE
include an explicit Provider wrapper

### DIFF
--- a/src/editors/content/common/draft/decorators/Extra.tsx
+++ b/src/editors/content/common/draft/decorators/Extra.tsx
@@ -11,6 +11,11 @@ import './styles.scss';
 import { RenderContext } from 'editors/content/common/AbstractContentEditor';
 import { getEditorByContentType } from 'editors/content/container/registry';
 import { ContiguousText } from 'data/content/learning/contiguous';
+import { accessStore } from 'utils/store';
+
+
+const Provider = (require('react-redux') as any).Provider;
+
 
 interface ExtraProps {
   services: AppServices;
@@ -52,7 +57,7 @@ class Extra extends React.PureComponent<ExtraProps, ExtraState> {
     this.setState({ tooltipShown: true });
   }
 
-  render() : JSX.Element {
+  render(): JSX.Element {
     const data = this.props.contentState.getEntity(this.props.entityKey).getData();
 
     const editor = getEditorByContentType('Extra');
@@ -66,12 +71,14 @@ class Extra extends React.PureComponent<ExtraProps, ExtraState> {
     const editorComponent = React.createElement(editor, props);
 
     const closeable = (
-      <RemovableContent title="Rollover"
-        onRemove={this.onClose.bind(this)} editMode={true} associatedClasses="">
-        <div className="tooltip-editor">
-          {editorComponent}
-        </div>
-      </RemovableContent>
+      <Provider store={accessStore()}>
+        <RemovableContent title="Rollover"
+          onRemove={this.onClose.bind(this)} editMode={true} associatedClasses="">
+          <div className="tooltip-editor">
+            {editorComponent}
+          </div>
+        </RemovableContent>
+      </Provider>
     );
 
     return (
@@ -92,7 +99,7 @@ class Extra extends React.PureComponent<ExtraProps, ExtraState> {
   }
 }
 
-export default function (props: Object) : Decorator {
+export default function (props: Object): Decorator {
   return {
     strategy: byType.bind(undefined, EntityTypes.extra),
     component: Extra,

--- a/src/editors/content/container/connectEditor.ts
+++ b/src/editors/content/container/connectEditor.ts
@@ -51,5 +51,5 @@ export const connectPopupEditor = (component) => {
     };
   };
 
-  return connect(mapStateToProps, mapDispatchToProps)(component);
+  return component;
 };


### PR DESCRIPTION
I still do not know what changed to break this, but explicitly inserting another Provider component restores the rollover editing functionality. 

RISK: Low
STABILITY: High, rollovers are now editable again