### PR TITLE
Authoring 1850 no modules

### DIFF
--- a/src/editors/document/org/OrgDetailsEditor.tsx
+++ b/src/editors/document/org/OrgDetailsEditor.tsx
@@ -38,6 +38,10 @@ function buildMoreInfoAction(display, dismiss) {
 
 function buildUnitsMessage(display, dismiss, labels: contentTypes.Labels) {
 
+  // Note that this could lead to incorrect pluralization, in cases
+  // where the user specifies something like 'Fish' or 'Deer' as the
+  // customized label.  After careful consideration, we feel that this
+  // an acceptable trade off to make. s
   const lowerCasedPlural = labels.module.toLowerCase() + 's';
 
   const content = new Messages.TitledContent().with({

--- a/src/editors/document/org/OrgDetailsEditor.tsx
+++ b/src/editors/document/org/OrgDetailsEditor.tsx
@@ -36,10 +36,13 @@ function buildMoreInfoAction(display, dismiss) {
   return moreInfoAction;
 }
 
-function buildUnitsMessage(display, dismiss) {
+function buildUnitsMessage(display, dismiss, labels: contentTypes.Labels) {
+
+  const lowerCasedPlural = labels.module.toLowerCase() + 's';
+
   const content = new Messages.TitledContent().with({
-    title: 'No modules.',
-    message: 'Organizations without modules have learning dashboard limitations in OLI',
+    title: `No ${lowerCasedPlural}.`,
+    message: `Organizations without ${lowerCasedPlural} have learning dashboard limitations in OLI`,
   });
 
   return new Messages.Message().with({
@@ -120,11 +123,13 @@ export class OrgDetailsEditor
 
       if (!containsOnly) {
         this.unitsMessageDisplayed = false;
-        props.dismissMessage(buildUnitsMessage(props.displayModal, props.dismissModal));
+        props.dismissMessage(buildUnitsMessage(
+          props.displayModal, props.dismissModal, model.labels));
 
       } else if (!this.unitsMessageDisplayed && containsOnly) {
         this.unitsMessageDisplayed = true;
-        props.showMessage(buildUnitsMessage(props.displayModal, props.dismissModal));
+        props.showMessage(buildUnitsMessage(
+          props.displayModal, props.dismissModal, model.labels));
       }
     });
   }

--- a/src/editors/document/org/OrgDetailsEditor.tsx
+++ b/src/editors/document/org/OrgDetailsEditor.tsx
@@ -38,15 +38,12 @@ function buildMoreInfoAction(display, dismiss) {
 
 function buildUnitsMessage(display, dismiss, labels: contentTypes.Labels) {
 
-  // Note that this could lead to incorrect pluralization, in cases
-  // where the user specifies something like 'Fish' or 'Deer' as the
-  // customized label.  After careful consideration, we feel that this
-  // an acceptable trade off to make. s
-  const lowerCasedPlural = labels.module.toLowerCase() + 's';
+  const lowerCased = labels.module.toLowerCase();
 
   const content = new Messages.TitledContent().with({
-    title: `No ${lowerCasedPlural}.`,
-    message: `Organizations without ${lowerCasedPlural} have learning dashboard limitations in OLI`,
+    title: `No ${lowerCased} found.`,
+    message:
+      `Organizations without at least one ${lowerCased} have learning dashboard limitations in OLI`,
   });
 
   return new Messages.Message().with({


### PR DESCRIPTION
This PR addresses the issue of hardcoded 'Modules' in the warning message by simply making the message title and text dynamic and including the custom label.

Note, we reworded the title and message slightly to avoid having to pluralize the custom term, since it is conceivable that a user could be using a term that isn't pluralized by simply adding an 's' to the end.

RISK: Low
STABILITY:  High, we tested this change in the browser and it works. 