### PR TITLE
only include bib if there are entries

### DIFF
--- a/src/data/models/workbook.ts
+++ b/src/data/models/workbook.ts
@@ -117,8 +117,11 @@ export class WorkbookPageModel extends Immutable.Record(defaultWorkbookPageModel
     const children = [
       this.head.toPersistence(),
       { body: { '#array': content } },
-      this.bibliography.toPersistence(),
     ];
+
+    if (this.bibliography.bibEntries.size > 0) {
+      children.push(this.bibliography.toPersistence());
+    }
 
     const doc = [{
       workbook_page: {


### PR DESCRIPTION
This PR adjusts logic in the WBP model to only serialize the bib:entries element if there are bib entries.  This prevents the resultant XML from containing an empty bib:file - which OLI is rendering as an empty "References" section

RISK: Low, isolated and well understood
STABILITY: High, tested and fixes the issue. 