### PR TITLE
Authoring 1985 simplify

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -90,10 +90,9 @@ export default class Main extends React.Component<MainProps, MainState> {
     onSetServerTimeSkew();
   }
 
-  onCreateOrg = () => {
+  onCreateOrg = (title: string) => {
     const { course, onUpdateCourseResources } = this.props;
 
-    const title = 'New Organization';
     const wbId = guid();
     const body = NEW_PAGE_CONTENT;
     const wb = models.WorkbookPageModel.createNew(wbId, 'Welcome', body);
@@ -105,7 +104,6 @@ export default class Main extends React.Component<MainProps, MainState> {
             const r = (result.model as OrganizationModel).resource;
             const updated = Immutable.OrderedMap<string, Resource>([[r.guid, r]]);
             onUpdateCourseResources(updated);
-            viewActions.viewDocument(r.id, course.idvers, Maybe.just(r.id));
           });
       });
   }
@@ -179,7 +177,6 @@ export default class Main extends React.Component<MainProps, MainState> {
                             course={loadedCourse}
                             route={route}
                             profile={user.profile}
-                            onCreateOrg={this.onCreateOrg}
                             userId={user.userId}
                             userName={user.user} />
                           <div className="main-splitview-content">
@@ -198,6 +195,7 @@ export default class Main extends React.Component<MainProps, MainState> {
                                 case 'RouteCourseOverview':
                                   return <CourseEditor
                                     model={loadedCourse}
+                                    onCreateOrg={this.onCreateOrg}
                                     editMode={loadedCourse.editable} />;
                                 case 'RouteResource': {
                                   const routeResource = route.route;

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -191,13 +191,6 @@ export default class Main extends React.Component<MainProps, MainState> {
                                     dispatch={onDispatch}
                                     expanded={expanded}
                                     userName={user.user} />;
-                                case 'RouteAllResources':
-                                  return <ResourceView
-                                    serverTimeSkewInMs={server.timeSkewInMs}
-                                    course={loadedCourse}
-                                    currentOrg={route.orgId.valueOr('')}
-                                    dispatch={onDispatch}
-                                  />;
                                 case 'RouteOrganizations':
                                 // Consider creating a page for the organizations
                                 case 'RouteSkills':

--- a/src/components/NavigationPanel.controller.ts
+++ b/src/components/NavigationPanel.controller.ts
@@ -1,11 +1,8 @@
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { NavigationPanel } from 'components/NavigationPanel';
 import * as viewActions from 'actions/view';
 import { State } from 'reducers';
-import { Document } from 'data/persistence';
 import { UserProfile } from 'types/user';
-import { load as loadOrg, releaseOrg } from 'actions/orgs';
 import { CourseIdVers } from 'data/types';
 import { preview } from 'actions/preview';
 import { RouteCourse } from 'types/router';
@@ -15,8 +12,6 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  onLoadOrg: (courseId: CourseIdVers, documentId: string) => Promise<Document>;
-  onReleaseOrg: () => void;
   onPreview: (courseId: CourseIdVers, organizationId: string, redeploy: boolean) =>
     Promise<any>;
 }
@@ -27,7 +22,6 @@ interface OwnProps {
   profile: UserProfile;
   userId: string;
   userName: string;
-  onCreateOrg: () => void;
 }
 
 const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {
@@ -46,9 +40,6 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
     {});
 
   return {
-    onLoadOrg: (courseId: CourseIdVers, documentId: string) =>
-      dispatch(loadOrg(courseId, documentId)),
-    onReleaseOrg: () => dispatch(releaseOrg() as any),
     onPreview: (courseId: CourseIdVers, organizationId: string, redeploy: boolean) =>
       dispatch(preview(courseId, organizationId, false, redeploy)),
   };

--- a/src/components/NavigationPanel.tsx
+++ b/src/components/NavigationPanel.tsx
@@ -464,11 +464,9 @@ class NavigationPanel
     );
   }
 
-  renderOrgDropdown(currentOrg: Resource) {
+  renderOrgRootNode(currentOrg: Resource) {
     const { classes, route, course } = this.props;
     const { collapsed } = this.state;
-
-
 
     const availableOrgs = r => r.type === 'x-oli-organization' && r.resourceState !== 'DELETED';
 
@@ -602,7 +600,7 @@ class NavigationPanel
 
         {this.renderOverview(currentOrg)}
         {this.renderObjectives(currentOrg)}
-        {this.renderOrgDropdown(currentOrg)}
+        {this.renderOrgRootNode(currentOrg)}
         {this.renderOrgTree(currentOrg, selectedItem)}
 
       </div>

--- a/src/components/NavigationPanel.tsx
+++ b/src/components/NavigationPanel.tsx
@@ -269,7 +269,6 @@ export interface NavigationPanelProps {
   profile: UserProfile;
   userId: string;
   userName: string;
-  onCreateOrg: () => void;
   onLoadOrg: (courseId: CourseIdVers, documentId: string) => Promise<Document>;
   onReleaseOrg: () => void;
   onPreview: (courseId: CourseIdVers, organizationId: string, redeploy: boolean) =>

--- a/src/components/NavigationPanel.tsx
+++ b/src/components/NavigationPanel.tsx
@@ -434,14 +434,14 @@ class NavigationPanel
     const { collapsed } = this.state;
 
     return (
-      <Tooltip disabled={!collapsed} title="Overview" position="right">
+      <Tooltip disabled={!collapsed} title="Course Details" position="right">
         <div
           className={classNames([
             classes.navItem,
             route.route.type === 'RouteCourseOverview' && classes.selectedNavItem,
           ])}
           onClick={() => viewActions.viewCourse(course.idvers, Maybe.just(currentOrg.id))}>
-          <i className="fa fa-book" />{!collapsed && ' Overview'}
+          <i className="fa fa-book" />{!collapsed && ' Course Details'}
         </div>
       </Tooltip>
     );
@@ -452,115 +452,45 @@ class NavigationPanel
     const { collapsed } = this.state;
 
     return (
-      <Tooltip disabled={!collapsed} title="Objectives" position="right">
+      <Tooltip disabled={!collapsed} title="Learning Objectives" position="right">
         <div className={classNames([
           classes.navItem,
           route.route.type === 'RouteObjectives' && classes.selectedNavItem,
         ])}
           onClick={() =>
             viewActions.viewObjectives(course.idvers, Maybe.just(currentOrg.id))}>
-          <i className="fa fa-graduation-cap" />{!collapsed && ' Objectives'}
+          <i className="fa fa-graduation-cap" />{!collapsed && ' Learning Objectives'}
         </div>
       </Tooltip>
-    );
-  }
-
-  renderAllResources(currentOrg: Resource) {
-    const { classes, course, route } = this.props;
-    const { collapsed } = this.state;
-
-    return (
-      <Tooltip disabled={!collapsed} title="All Resources" position="right">
-        <div
-          className={classNames([
-            classes.navItem,
-            route.route.type === 'RouteAllResources' && classes.selectedNavItem,
-          ])}
-          onClick={() =>
-            viewActions.viewAllResources(course.idvers, Maybe.just(currentOrg.id))}>
-          <i className="fas fa-folder-open" />{!collapsed && ' All Resources'}
-        </div>
-      </Tooltip>
-
     );
   }
 
   renderOrgDropdown(currentOrg: Resource) {
-    const { classes, route, profile, course, onCreateOrg } = this.props;
-    const { showOrgDropdown, collapsed } = this.state;
+    const { classes, route, course } = this.props;
+    const { collapsed } = this.state;
+
+
 
     const availableOrgs = r => r.type === 'x-oli-organization' && r.resourceState !== 'DELETED';
 
+    const orgCount = course.resources.toArray().filter(availableOrgs).length;
+    const title = orgCount === 1
+      ? 'Course Outline'
+      : currentOrg.title;
+
     return (
-      <div className="dropdown">
+      <Tooltip disabled={!collapsed} title={title} position="right">
         <div className={classNames([
-          classes.navItemDropdown,
-          route.route.type === 'RouteResource'
-          && route.route.resourceId === currentOrg.id
-          && classes.selectedNavItem,
-        ])}>
-          <Tooltip
-            disabled={!collapsed}
-            title={`${currentOrg.title} (${currentOrg.id})`}
-            position="right"
-            distance={32}
-            style={{ overflow: 'hidden', flex: 1, display: 'flex' }}>
-            <div className={classNames([
-              classes.dropdownText,
-              collapsed && classes.dropdownTextCollapsed,
-            ])}
-              onClick={() => viewActions.viewDocument(
-                currentOrg.id, course.idvers, Maybe.just(currentOrg.id))}>
-              <i className="fa fa-th-list" />{!collapsed && ` ${currentOrg.title}`}
-            </div>
-          </Tooltip>
-          <div className={classNames([
-            classes.dropdownToggle,
-            collapsed && classes.dropdownToggleCollapsed,
-          ])}
-            onClick={(e) => {
-              (e.nativeEvent as any).originator = 'OrgDropdownToggle';
-              this.setState({ showOrgDropdown: !showOrgDropdown });
-            }}>
-            <i className={'fas fa-sort-down'} />
-          </div>
+          classes.navItem,
+          (route.route as any).resourceId === currentOrg.id && classes.selectedNavItem,
+        ])}
+          onClick={() => viewActions.viewDocument(
+            currentOrg.id, course.idvers, Maybe.just(currentOrg.id))}>
+          <i className="fa fa-list-alt" />{!collapsed && (' ' + title)}
         </div>
-        <div className={classNames(['dropdown-menu', showOrgDropdown && 'show'])}>
-          {course.resources.valueSeq()
-            .filter(availableOrgs)
-            .sort((r1, r2) => {
-              return r1.title.toLowerCase() < r2.title.toLowerCase()
-                ? -1
-                : r1.title.toLowerCase() > r2.title.toLowerCase()
-                  ? 1
-                  : 0;
-            })
-            .map(org => (
-              <a key={org.guid}
-                className={classNames([
-                  'dropdown-item',
-                  currentOrg.id === org.id && classes.selectedNavItem,
-                ])}
-                onClick={() => {
-                  if (org.id !== currentOrg.id) {
-                    this.props.onReleaseOrg();
-                    updateActiveOrgPref(course.idvers, profile.username, org.id);
-                    this.props.onLoadOrg(course.idvers, org.guid);
-                    viewActions.viewDocument(org.id, course.idvers, Maybe.just(org.id));
-                  }
-                }}>
-                {org.title} <span style={{ color: colors.gray }}>({org.id})</span>
-              </a>
-            ))}
-          <div className="dropdown-divider" />
-          <a key="create-org"
-            className={classNames(['dropdown-item'])}
-            onClick={() => onCreateOrg()}>
-            <i className={'fa fa-plus-circle'} /> Create New Organization
-          </a>
-        </div>
-      </div>
+      </Tooltip>
     );
+
   }
 
   renderOrgTree(currentOrg: Resource, selectedItem: Maybe<nav.NavigationItem>) {
@@ -673,7 +603,6 @@ class NavigationPanel
 
         {this.renderOverview(currentOrg)}
         {this.renderObjectives(currentOrg)}
-        {this.renderAllResources(currentOrg)}
         {this.renderOrgDropdown(currentOrg)}
         {this.renderOrgTree(currentOrg, selectedItem)}
 

--- a/src/components/OrgLibrary.tsx
+++ b/src/components/OrgLibrary.tsx
@@ -1,0 +1,152 @@
+
+
+import { Resource, ResourceState } from 'data/content/resource';
+import * as models from 'data/models';
+import * as React from 'react';
+import { relativeToNow } from 'utils/date';
+import { LegacyTypes } from 'data/types';
+import './ResourceView.scss';
+
+export interface OrgLibraryProps {
+  course: models.CourseModel;
+  currentOrg: Resource;
+  onCreateOrg: (title: string) => void;
+  onSelectOrg: (id: string) => void;
+}
+
+interface OrgLibraryState {
+  newItemTitle: string;
+}
+
+export default class OrgLibrary extends React.Component<OrgLibraryProps, OrgLibraryState> {
+
+  state = {
+    ...this.state,
+    newItemTitle: '',
+  };
+
+
+  getOrgs(): Resource[] {
+    const { course } = this.props;
+
+    return course.resources.toArray().filter(r =>
+      r.resourceState !== ResourceState.DELETED
+      && r.type === LegacyTypes.organization,
+    );
+  }
+
+  onNewItemTitleChange = (newItemTitle: string) => {
+    this.setState({
+      newItemTitle,
+    });
+  }
+
+  renderCreation() {
+    const { course } = this.props;
+    const { newItemTitle } = this.state;
+
+    return (
+      <div className="table-toolbar">
+        <div className="input-group">
+          <div className="flex-spacer" />
+          <div className="btn-group">
+            <input type="text"
+              style={{ width: 300 }}
+              value={newItemTitle}
+              disabled={!course.editable}
+              className="form-control mb-2 mr-sm-2 mb-sm-0" id="inlineFormInput"
+              onChange={({ target: { value } }) => this.setState({ newItemTitle: value })}
+              placeholder="Enter title for new organization" />
+            <button
+              disabled={!course.editable || !newItemTitle}
+              onClick={() => this.props.onCreateOrg(newItemTitle)}
+              className="btn btn-primary">
+              Create New
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderResources() {
+
+    const items = this.getOrgs().map((org) => {
+
+      const currentOrgId = this.props.currentOrg !== null
+        ? this.props.currentOrg.id
+        : null;
+
+      const thisId = org.id;
+      const active = thisId === currentOrgId
+        ? <small><b><span style={{ color: 'darkgreen' }}>
+          Active organization</span></b></small>
+        : <small>&nbsp;</small>;
+      const classes
+        = 'list-group-item list-group-item-action align-items-start flex-column';
+      const since = relativeToNow(org.dateUpdated);
+
+      const onClick = thisId === currentOrgId
+        ? undefined
+        : (e) => { e.preventDefault(); this.props.onSelectOrg(thisId); };
+
+      return (
+        <li
+          key={org.id}
+          className={classes}>
+          <div
+            className="d-flex w-100 justify-content-between"
+            onClick={onClick}>
+            <h5 className="mb-1">
+              <a href="#" onClick={onClick}>{org.title}</a>
+            </h5>
+            <small><b>Last updated {since}</b></small>
+          </div>
+          <div
+            className="d-flex w-100 justify-content-between"
+            onClick={onClick}>
+            {active}
+            <small>Id: {org.id}</small>
+          </div>
+        </li>
+      );
+    });
+
+    return (
+      <div>
+        <ul className="list-group">
+          {items}
+        </ul>
+      </div>
+    );
+  }
+
+  renderDescription() {
+    return (
+      <p><b>Organizations</b> are an advanced feature that allow a course package to
+        support more than one arrangement of the course material.
+      </p>
+    );
+  }
+
+  render() {
+    return (
+      <div className="resource-view container-fluid new">
+        <div className="row">
+          <div className="col-sm-12 col-md-12 document">
+            <div className="container-fluid editor">
+              <div className="row">
+                <div className="col-12">
+                  {this.renderDescription()}
+                  {this.renderCreation()}
+                  {this.renderResources()}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/src/components/PasteFailModalElement.tsx
+++ b/src/components/PasteFailModalElement.tsx
@@ -19,7 +19,7 @@ export class PasteFailModalElement extends React.PureComponent<PasteFailModalEle
           {removed.map(r => (
             <li key={r}>{r === 'WbInline' ? 'Inline Assessment' : r}</li>
           ))}
-        </ul>
+        </ul> 
       </div>
     );
   }

--- a/src/components/ResourceView.tsx
+++ b/src/components/ResourceView.tsx
@@ -243,8 +243,7 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
     ];
 
     return (
-      <div className="">
-        <h2>All Resources</h2>
+      <div>
 
         {this.renderCreation()}
 

--- a/src/data/models/utils/org.ts
+++ b/src/data/models/utils/org.ts
@@ -10,6 +10,7 @@ import { LegacyTypes } from 'data/types';
 
 
 export type OrgNode =
+  ct.Sequences |
   ct.Sequence |
   ct.Unit |
   ct.Module |
@@ -90,10 +91,8 @@ export function modelToPlacements(
   const placements = [];
   const arr = model.sequences.children.toArray();
 
-  arr.forEach((n) => {
-    modelToPlacementsHelper(
-      n, 0, positions, positionAtLevels, placements, Maybe.nothing());
-  });
+  modelToPlacementsHelper(
+    model.sequences, 0, positions, positionAtLevels, placements, Maybe.nothing());
 
   return Immutable.OrderedMap<string, Placement>(
     placements.map(p => [p.node.id, p]));

--- a/src/data/models/utils/org.ts
+++ b/src/data/models/utils/org.ts
@@ -10,7 +10,6 @@ import { LegacyTypes } from 'data/types';
 
 
 export type OrgNode =
-  ct.Sequences |
   ct.Sequence |
   ct.Unit |
   ct.Module |
@@ -89,10 +88,12 @@ export function modelToPlacements(
   const positions = {};
   const positionAtLevels = {};
   const placements = [];
-  const arr = model.sequences.children.toArray();
 
-  modelToPlacementsHelper(
-    model.sequences, 0, positions, positionAtLevels, placements, Maybe.nothing());
+  const arr = model.sequences.children.toArray();
+  arr.forEach((n) => {
+    modelToPlacementsHelper(
+      n, 0, positions, positionAtLevels, placements, Maybe.nothing());
+  });
 
   return Immutable.OrderedMap<string, Placement>(
     placements.map(p => [p.node.id, p]));

--- a/src/editors/document/course/CourseEditor.controller.ts
+++ b/src/editors/document/course/CourseEditor.controller.ts
@@ -13,6 +13,7 @@ import { showMessage } from 'actions/messages';
 interface StateProps {
   user: UserState;
   analytics: AnalyticsState;
+  currentOrg: string;
 }
 
 interface DispatchProps {
@@ -22,6 +23,7 @@ interface DispatchProps {
   onDismissModal: () => void;
   onCreateDataset: () => void;
   onShowMessage: (message: Messages.Message) => void;
+  dispatch: any;
 }
 
 interface OwnProps {
@@ -33,18 +35,21 @@ const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
   return {
     user: state.user,
     analytics: state.analytics,
+    currentOrg: state.orgs.activeOrg.caseOf(
+      { just: doc => (doc as any).model.id, nothing: () => null }),
   };
 };
 
-const mapDispatchToProps = (dispatch): DispatchProps => {
+const mapDispatchToProps = (d): DispatchProps => {
   return {
     courseChanged: (model: CourseModel) =>
-      dispatch(courseChanged(model)),
+      d(courseChanged(model)),
     viewAllCourses: () => viewActions.viewAllCourses(),
-    onDisplayModal: component => dispatch(modalActions.display(component)),
-    onDismissModal: () => dispatch(modalActions.dismiss()),
-    onShowMessage: (message: Messages.Message) => dispatch(showMessage(message)),
-    onCreateDataset: () => dispatch(createNewDataSet()),
+    onDisplayModal: component => d(modalActions.display(component)),
+    onDismissModal: () => d(modalActions.dismiss()),
+    onShowMessage: (message: Messages.Message) => d(showMessage(message)),
+    onCreateDataset: () => d(createNewDataSet()),
+    dispatch: d,
   };
 };
 

--- a/src/editors/document/course/CourseEditor.controller.ts
+++ b/src/editors/document/course/CourseEditor.controller.ts
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import CourseEditor from './CourseEditor';
+import * as persistence from 'data/persistence';
 import { CourseModel } from 'data/models';
 import { courseChanged } from 'actions/course';
 import * as viewActions from 'actions/view';
@@ -9,34 +10,41 @@ import { AnalyticsState } from 'reducers/analytics';
 import { UserState } from 'reducers/user';
 import * as Messages from 'types/messages';
 import { showMessage } from 'actions/messages';
+import { load as loadOrg, releaseOrg } from 'actions/orgs';
+import { CourseIdVers } from 'data/types';
 
 interface StateProps {
   user: UserState;
   analytics: AnalyticsState;
-  currentOrg: string;
+  currentOrgDoc: persistence.Document;
 }
 
 interface DispatchProps {
+  onLoadOrg: (courseId: CourseIdVers, documentId: string) => Promise<persistence.Document>;
+  onReleaseOrg: () => void;
   courseChanged: (model: CourseModel) => void;
   viewAllCourses: () => void;
   onDisplayModal: (component: any) => void;
   onDismissModal: () => void;
   onCreateDataset: () => void;
   onShowMessage: (message: Messages.Message) => void;
+
   dispatch: any;
 }
 
 interface OwnProps {
   model: CourseModel;
   editMode: boolean;
+  onCreateOrg: (title: string) => void;
 }
 
 const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
+
   return {
     user: state.user,
     analytics: state.analytics,
-    currentOrg: state.orgs.activeOrg.caseOf(
-      { just: doc => (doc as any).model.id, nothing: () => null }),
+    currentOrgDoc: state.orgs.activeOrg.caseOf(
+      { just: doc => doc, nothing: () => null }),
   };
 };
 
@@ -49,6 +57,9 @@ const mapDispatchToProps = (d): DispatchProps => {
     onDismissModal: () => d(modalActions.dismiss()),
     onShowMessage: (message: Messages.Message) => d(showMessage(message)),
     onCreateDataset: () => d(createNewDataSet()),
+    onLoadOrg: (courseId: CourseIdVers, documentId: string) =>
+      d(loadOrg(courseId, documentId)),
+    onReleaseOrg: () => d(releaseOrg() as any),
     dispatch: d,
   };
 };

--- a/src/editors/document/course/CourseEditor.tsx
+++ b/src/editors/document/course/CourseEditor.tsx
@@ -30,6 +30,7 @@ import { Maybe } from 'tsmonad';
 import * as Messages from 'types/messages';
 import { buildGeneralErrorMessage } from 'utils/error';
 import { configuration } from 'actions/utils/config';
+import ResourceView from 'components/ResourceView';
 
 // const THUMBNAIL = require('../../../../assets/ph-courseView.png');
 const CC_LICENSES = require('../../../../assets/cclicenses.png');
@@ -39,6 +40,8 @@ export interface CourseEditorProps {
   model: models.CourseModel;
   editMode: boolean;
   analytics: AnalyticsState;
+  currentOrg: string;
+  dispatch: any;
   courseChanged: (m: models.CourseModel) => any;
   viewAllCourses: () => any;
   onDisplayModal: (component: any) => void;
@@ -670,46 +673,46 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
         }
         <div className="row">
           <div className="col-3">
-              <button
-                type="button"
-                className="btn btn-link"
-                onClick={() => this.toggleAdvancedDetails()}>
-                Advanced Details {collapseIndicator}
-              </button>
+            <button
+              type="button"
+              className="btn btn-link"
+              onClick={() => this.toggleAdvancedDetails()}>
+              Advanced Details {collapseIndicator}
+            </button>
           </div>
           <div className="col-9"></div>
         </div>
         {this.state.showAdvancedDetails &&
           <div className="advanced">
-          <div className="row">
-            <div className="col-3">Theme</div>
-            <div className="col-9">{this.renderThemes()}</div>
-          </div>
-          <div className="row">
-            <div className="col-3">Version</div>
-            <div className="col-9">{model.version}</div>
-          </div>
-          <div className="row">
-            <div className="col-3">License <HelpPopover activateOnClick>
-              <div><img src={CC_LICENSES} />
-                <br /><br />
-                <a href="https://en.wikipedia.org/wiki/Creative_Commons_license"
-                  target="_blank">
-                  More information
-                </a>
-              </div>
-            </HelpPopover>
+            <div className="row">
+              <div className="col-3">Theme</div>
+              <div className="col-9">{this.renderThemes()}</div>
             </div>
-            <div className="col-9">{this.renderLicenseSelect()}</div>
-          </div>
-          <div className="row">
-            <div className="col-3">Unique ID</div>
-            <div className="col-9">{model.id}</div>
-          </div>
-          <div className="row">
-            <div className="col-3">Package Location</div>
-            <div className="col-9">{model.svnLocation}</div>
-          </div>
+            <div className="row">
+              <div className="col-3">Version</div>
+              <div className="col-9">{model.version}</div>
+            </div>
+            <div className="row">
+              <div className="col-3">License <HelpPopover activateOnClick>
+                <div><img src={CC_LICENSES} />
+                  <br /><br />
+                  <a href="https://en.wikipedia.org/wiki/Creative_Commons_license"
+                    target="_blank">
+                    More information
+                </a>
+                </div>
+              </HelpPopover>
+              </div>
+              <div className="col-9">{this.renderLicenseSelect()}</div>
+            </div>
+            <div className="row">
+              <div className="col-3">Unique ID</div>
+              <div className="col-9">{model.id}</div>
+            </div>
+            <div className="row">
+              <div className="col-3">Package Location</div>
+              <div className="col-9">{model.svnLocation}</div>
+            </div>
           </div>
         }
 
@@ -758,6 +761,19 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
     );
   }
 
+  renderResources() {
+    const { model, currentOrg, dispatch } = this.props;
+
+    return (
+      <ResourceView
+        course={model}
+        dispatch={dispatch}
+        currentOrg={currentOrg}
+        serverTimeSkewInMs={0}
+      />
+    );
+  }
+
   renderAnalytics() {
     const { user, analytics, onCreateDataset, editMode, model } = this.props;
 
@@ -798,7 +814,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
                       <React.Fragment>
                         Analytics for this course are based on the latest dataset, which was created
                       {' '}<b>{dateFormatted(parseDate(dataSet.dateCreated))}</b>.
-                            To get the most recent data for analytics, create a new dataset.
+                              To get the most recent data for analytics, create a new dataset.
                         <br />
                         <br />
                         <b>Notice:</b> Dataset creation may take a few minutes depending on the size
@@ -855,7 +871,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
         <div className="row info">
           <div className="col-md-12">
             <h2>Course Package</h2>
-            <TabContainer labels={['Details', 'Workflow', 'Analytics']}>
+            <TabContainer labels={['Details', 'Workflow', 'Analytics', 'Resources']}>
               <Tab>
                 {this.renderDetails()}
               </Tab>
@@ -864,6 +880,9 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
               </Tab>
               <Tab>
                 {this.renderAnalytics()}
+              </Tab>
+              <Tab>
+                {this.renderResources()}
               </Tab>
             </TabContainer>
           </div>

--- a/src/editors/document/org/TreeNode.tsx
+++ b/src/editors/document/org/TreeNode.tsx
@@ -24,7 +24,7 @@ export interface TreeNodeProps {
   editMode: boolean;
   onClick: (model: NodeTypes) => void;
   onReposition: (
-  sourceNode: Object, sourceParentGuid: string, targetModel: any, index: number) => void;
+    sourceNode: Object, sourceParentGuid: string, targetModel: any, index: number) => void;
 }
 
 export interface TreeNodeState {


### PR DESCRIPTION
This PR simplifies the navigation panel in the following ways:

1) Renames first two tabs to "Course Details" and "Learning Objectives" 
2) Moves the "All resources" tab to a tab on the Course editor page. 
3) Removes the Organization dropdown component - and replaces it with the OrgLibrary component, now a tab on the CourseEditor view.

RISK: Low/Medium - Some non-trivial structural changes across a few key components in the system 
STABILITY: High, tested and seems to be working nicely