### PR TITLE
HOTFIX -- 1974 - user can edit the Title for an Alternative object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.32.0",
+  "version": "0.31.1",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/content/learning/AlternativeEditor.tsx
+++ b/src/editors/content/learning/AlternativeEditor.tsx
@@ -13,6 +13,9 @@ import { ToolbarButton, ToolbarButtonSize } from 'components/toolbar/ToolbarButt
 import { CONTENT_COLORS } from 'editors/content/utils/content';
 import { TextInput } from '../common/controls';
 import { Maybe } from 'tsmonad';
+import { TitleTextEditor } from 'editors/content/learning/contiguoustext/TitleTextEditor';
+import { ContentElements, TEXT_ELEMENTS } from 'data/content/common/elements';
+import { ContiguousText } from 'data/content/learning/contiguous';
 import {
   Discoverable, DiscoverableId,
 } from 'components/common/Discoverable.controller';
@@ -48,8 +51,40 @@ class AlternativeEditor
     this.props.onEdit(model, model);
   }
 
+  /**
+   * Note that for this soution, we must use a Title Editor
+   * This is called when the user edits the Title via the Title Editor
+   */
+  onTitleEdit(ct: ContiguousText, sourceObject) {
+    const content = this.props.model.title.text.content.set(ct.guid, ct);
+    const text = this.props.model.title.text.with({ content });
+    const title = this.props.model.title.with({ text });
+    const model = this.props.model.with({ title });
+    this.props.onEdit(model, sourceObject);
+  }
+
+  /**
+   * This is called when the user edits the Title via the sidebar (for design consistency)
+   * @param titleText
+   */
+  onSideTitleEdit(titleText: string) {
+    const title = new contentTypes.Title({
+      text: ContentElements.fromText(titleText, '', TEXT_ELEMENTS),
+    });
+
+    const model = this.props.model.with({ title });
+    this.props.onEdit(model, model);
+
+  }
+
   renderSidebar() {
     const { model, editMode } = this.props;
+
+    // must be stripped out of the Title object
+    const titleText = model.title.text.extractPlainText().caseOf({
+      just: t => t,
+      nothing: () => '',
+    });
 
     return (
       <SidebarContent title={model.value}>
@@ -62,6 +97,18 @@ class AlternativeEditor
               width="100%"
               label=""
               onEdit={this.onValueEdit.bind(this)}
+            />
+          </Discoverable>
+        </SidebarGroup>
+        <SidebarGroup label="Title">
+          <Discoverable id={DiscoverableId.AlternativeEditorKey} focusChild>
+            <TextInput
+              editMode={editMode}
+              value={titleText}
+              type="text"
+              width="100%"
+              label=""
+              onEdit={this.onSideTitleEdit.bind(this)}
             />
           </Discoverable>
         </SidebarGroup>
@@ -92,6 +139,17 @@ class AlternativeEditor
     return (
       <div className={classNames([classes.alternative, className])}
         onClick={() => this.props.onFocus(model, parent, Maybe.nothing())}>
+        {/* FIXME: for some reason, this Title value changes
+        when the "model.value" is edited via the Sidebar */}
+        <TitleTextEditor
+          context={this.props.context}
+          services={this.props.services}
+          onFocus={this.props.onFocus}
+          model={(this.props.model.title.text.content.first() as ContiguousText)}
+          editMode={this.props.editMode}
+          onEdit={this.onTitleEdit.bind(this)}
+        editorStyles={{ fontSize: 20, fontWeight: 600 }} />
+
         <ContentContainer
           {...this.props}
           model={this.props.model.content}

--- a/src/editors/content/learning/AlternativeEditor.tsx
+++ b/src/editors/content/learning/AlternativeEditor.tsx
@@ -139,8 +139,7 @@ class AlternativeEditor
     return (
       <div className={classNames([classes.alternative, className])}
         onClick={() => this.props.onFocus(model, parent, Maybe.nothing())}>
-        {/* FIXME: for some reason, this Title value changes
-        when the "model.value" is edited via the Sidebar */}
+
         <TitleTextEditor
           context={this.props.context}
           services={this.props.services}

--- a/src/editors/content/learning/AlternativesEditor.tsx
+++ b/src/editors/content/learning/AlternativesEditor.tsx
@@ -148,13 +148,7 @@ class AlternativesEditor
     );
   }
 
-  onAlternativeEdit(a: contentTypes.Alternative, src) {
-
-    // If the value has been edited, sync that content into the title
-    const previous = this.props.model.content.get(a.guid);
-    const updated = a.value === previous.value
-      ? a
-      : a.with({ title: contentTypes.Title.fromText(a.value) });
+  onAlternativeEdit(updated: contentTypes.Alternative, src) {
 
     // Ignore the edit if it would result in multiple alternatives
     // having the same value


### PR DESCRIPTION
- user can edit the Title via 
  (a) a <TitleTextEditor
  (b) the Sidebar Editor

- this is not the ideal solution, as discussed [here](https://olidev.atlassian.net/browse/AUTHORING-1974?atlOrigin=eyJpIjoiOTFjYTU4NzhjODJjNDZmODkwMzgzYTBhZDgzOTY4MzQiLCJwIjoiaiJ9)
- there is a slight bug where editing the Value will change the Title, but this is avoidable

RISK: Low -- changes contained to a single file
STABILITY: High -- no unit tests, but is a relatively consistent change