### PR TITLE
Fix course IDs showing as "undefined" in course list, fix resource locking

### DIFF
--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -12,7 +12,7 @@ import { highlightMatchesStr } from 'components/common/SearchBarLogic';
 import { adjustForSkew, compareDates, relativeToNow } from 'utils/date';
 import { safeCompare } from 'components/ResourceView';
 import { buildGeneralErrorMessage } from 'utils/error';
-import { CourseIdVers, CourseGuid, CourseId } from 'data/types';
+import { CourseIdVers, CourseGuid } from 'data/types';
 
 function reportProblemAction(): Messages.MessageAction {
 

--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -12,7 +12,7 @@ import { highlightMatchesStr } from 'components/common/SearchBarLogic';
 import { adjustForSkew, compareDates, relativeToNow } from 'utils/date';
 import { safeCompare } from 'components/ResourceView';
 import { buildGeneralErrorMessage } from 'utils/error';
-import { CourseIdVers, CourseGuid } from 'data/types';
+import { CourseIdVers, CourseGuid, CourseId } from 'data/types';
 
 function reportProblemAction(): Messages.MessageAction {
 
@@ -43,6 +43,7 @@ function errorMessageAction(): Messages.Message {
 export type CourseDescription = {
   guid: CourseGuid,
   idvers: CourseIdVers,
+  id: string,
   version: string,
   title: string,
   description: string,
@@ -86,9 +87,9 @@ class CoursesViewSearchable extends React.PureComponent<CoursesViewProps, Course
     const searchText = this.state.searchText;
     const text = searchText.trim().toLowerCase();
     const filterFn = (r: CourseDescription): boolean => {
-      const { title, idvers, version } = r;
+      const { title, id, version } = r;
       const titleLower = title ? title.toLowerCase() : '';
-      const idLower = idvers.value() ? idvers.value().toLowerCase() : '';
+      const idLower = id ? id.toLowerCase() : '';
       const versionLower = version ? version.toLowerCase() : '';
 
       return text === '' ||
@@ -108,6 +109,7 @@ class CoursesViewSearchable extends React.PureComponent<CoursesViewProps, Course
         const courses: CourseDescription[] = docs.map(d => ({
           guid: d.guid,
           idvers: d.idvers,
+          id: d.id,
           version: d.version,
           title: d.title,
           dateCreated: d.dateCreated,
@@ -249,10 +251,12 @@ const CoursesViewSearchableTable = ({ rows, onSelect, searchText, serverTimeSkew
 
   const highlightedColumnRenderer = (
     prop: string,
-    r: CourseDescription, appendText: string = '') =>
-    searchText.length < 3
+    r: CourseDescription, appendText: string = '') => {
+    console.log('r[prop]', r[prop])
+    return searchText.length < 3
       ? <span>{r[prop] + appendText}</span>
-      : highlightMatchesStr(r[prop] + appendText, searchText);
+      : highlightMatchesStr(r[prop] + appendText, searchText)
+  };
 
   const comparators = [
     (direction, a, b) => safeCompare('title', 'id', direction, a, b),

--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -251,12 +251,9 @@ const CoursesViewSearchableTable = ({ rows, onSelect, searchText, serverTimeSkew
 
   const highlightedColumnRenderer = (
     prop: string,
-    r: CourseDescription, appendText: string = '') => {
-    console.log('r[prop]', r[prop])
-    return searchText.length < 3
+    r: CourseDescription, appendText: string = '') => searchText.length < 3
       ? <span>{r[prop] + appendText}</span>
-      : highlightMatchesStr(r[prop] + appendText, searchText)
-  };
+      : highlightMatchesStr(r[prop] + appendText, searchText);
 
   const comparators = [
     (direction, a, b) => safeCompare('title', 'id', direction, a, b),

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -21,6 +21,7 @@ class Id {
 
   apply = f => f(this.val);
   value: () => string = () => this.apply(identity);
+  toString = this.value;
   eq = (x: Id) => this.type === x.type && this.val === x.val;
 }
 

--- a/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
@@ -37,7 +37,6 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
 
     // Release the write lock if it was acquired, but fetch
     // the document first to get the most up to date version
-    console.log('this.courseId', this.courseId)
     if (this.writeLockedDocumentId !== null) {
       return persistence.releaseLock(CourseGuid.of(this.courseId),
         this.writeLockedDocumentId);

--- a/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/AbstractPersistenceStrategy.ts
@@ -37,7 +37,7 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
 
     // Release the write lock if it was acquired, but fetch
     // the document first to get the most up to date version
-
+    console.log('this.courseId', this.courseId)
     if (this.writeLockedDocumentId !== null) {
       return persistence.releaseLock(CourseGuid.of(this.courseId),
         this.writeLockedDocumentId);
@@ -68,16 +68,16 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
           : doc._courseId,
         typeof doc._id === 'string'
           ? doc._id
-          : '')
+          : doc._id.value())
         .then((result) => {
           if ((result as any).lockedBy === userName) {
             this.lockDetails = (result as any);
             this.writeLockedDocumentId = typeof doc._id === 'string'
               ? doc._id
-              : '';
+              : doc._id.value();
             this.courseId = typeof doc._courseId === 'string'
               ? doc._courseId
-              : '';
+              : doc._courseId.value();
 
             resolve(true);
 


### PR DESCRIPTION
Fix:
- Course IDs showing up as undefined in the all courses list
- Course resources were not properly locked

This code is refactored in the resource ID PR, but this temporary fix will work until that is merged.

Risk: low
Stability: stable