### PR TITLE
Authoring 2014 unit module swap

### DIFF
--- a/src/data/models/utils/org.ts
+++ b/src/data/models/utils/org.ts
@@ -90,6 +90,8 @@ export function addContainer(
 
 }
 
+// Counts all intances of nodes of a particular content type
+// within an arbitrary hierarchy
 function countIn(node: OrgNode, contentType: string): number {
   let count = 0;
 
@@ -102,6 +104,9 @@ function countIn(node: OrgNode, contentType: string): number {
   return count;
 }
 
+// Possibly translates modules to units and sections to modules
+// in one or more sequences of an organization.  This is designed
+// to be used after a section has just been added to an org.
 export function translateModulesToUnits(org: OrganizationModel): Maybe<OrganizationModel> {
 
   let updatedOrg = org;
@@ -155,7 +160,6 @@ export function translateModulesToUnits(org: OrganizationModel): Maybe<Organizat
             });
 
             unit = unit.with({ children: unitChildren });
-
             children = children.set(unit.guid, unit);
 
           } else {
@@ -178,7 +182,8 @@ export function translateModulesToUnits(org: OrganizationModel): Maybe<Organizat
   return Maybe.nothing();
 }
 
-
+// Create a container with a type that makes sense give the
+// supplied parent node.
 function createContainer(node: OrgNode | ct.Sequences): OrgNode {
   if (node.contentType === 'Sequences') {
     return new ct.Sequence().with({ title: 'New Container' });

--- a/test/data/models/utils/conversion-test.ts
+++ b/test/data/models/utils/conversion-test.ts
@@ -1,20 +1,7 @@
-
-import * as contentTypes from 'data/contentTypes';
 import { Maybe } from 'tsmonad';
 import * as org from 'data/models/utils/org';
 import { OrganizationModel } from 'data/models/org';
 import { map } from 'data/utils/map';
-
-it('calculates depths', () => {
-
-  [1, 2, 3].forEach((n) => {
-    const orgData = require('./depth-' + n + '.json');
-    const model = OrganizationModel.fromPersistence(orgData, () => null);
-
-    expect(org.calcDepth(model.sequences.children.first() as contentTypes.Sequence)).toBe(+n);
-  });
-
-});
 
 
 it('finds the parent container', () => {
@@ -31,45 +18,15 @@ it('finds the parent container', () => {
 });
 
 
-it('can insert a child', () => {
-
-  const orgData = require('./depth-3.json');
-  const model = OrganizationModel.fromPersistence(orgData, () => null);
-
-  const node = org.findContainerOrParent(model, Maybe.just('section'));
-
-  const item = new contentTypes.Include({ id: 'include' });
-  const updated = org.insertAsChild(model, node, item);
-
-  const section = org.findContainerOrParent(updated, Maybe.just('include'));
-  expect(section.id).toBe('section');
-
-});
-
-
-
 it('does not translates modules to units', () => {
 
   const orgData = require('./depth-2.json');
   const model = OrganizationModel.fromPersistence(orgData, () => null);
 
-  const updated = org.translateModulesToUnits(model);
-
-  let moduleCount = 0;
-  let unitCount = 0;
-
-  map((e) => {
-    if (e.contentType === 'Unit') {
-      unitCount += 1;
-    }
-    if (e.contentType === 'Module') {
-      moduleCount += 1;
-    }
-    return e;
-  }, updated as any);
-
-  expect(moduleCount).toBe(1);
-  expect(unitCount).toBe(0);
+  org.translateModulesToUnits(model).caseOf({
+    just: m => fail('should have been nothing'),
+    nothing: () => expect(1).toBe(1),
+  });
 
 });
 
@@ -78,27 +35,32 @@ it('translates modules to units and sections to modules', () => {
   const orgData = require('./depth-3.json');
   const model = OrganizationModel.fromPersistence(orgData, () => null);
 
-  const updated = org.translateModulesToUnits(model);
+  org.translateModulesToUnits(model).caseOf({
+    just: (m) => {
 
-  let moduleCount = 0;
-  let unitCount = 0;
-  let sectionCount = 0;
+      let moduleCount = 0;
+      let unitCount = 0;
+      let sectionCount = 0;
 
-  map((e) => {
-    if (e.contentType === 'Unit') {
-      unitCount += 1;
-    }
-    if (e.contentType === 'Module') {
-      moduleCount += 1;
-    }
-    if (e.contentType === 'Section') {
-      sectionCount += 1;
-    }
-    return e;
-  }, updated as any);
+      map((e) => {
+        if (e.contentType === 'Unit') {
+          unitCount += 1;
+        }
+        if (e.contentType === 'Module') {
+          moduleCount += 1;
+        }
+        if (e.contentType === 'Section') {
+          sectionCount += 1;
+        }
+        return e;
+      }, m as any);
 
-  expect(moduleCount).toBe(1);
-  expect(unitCount).toBe(1);
-  expect(sectionCount).toBe(0);
+      expect(moduleCount).toBe(1);
+      expect(unitCount).toBe(1);
+      expect(sectionCount).toBe(0);
+    },
+    nothing: () => fail('should have been just a model'),
+  });
+
 
 });

--- a/test/data/models/utils/conversion-test.ts
+++ b/test/data/models/utils/conversion-test.ts
@@ -1,0 +1,104 @@
+
+import * as contentTypes from 'data/contentTypes';
+import { Maybe } from 'tsmonad';
+import * as org from 'data/models/utils/org';
+import { OrganizationModel } from 'data/models/org';
+import { map } from 'data/utils/map';
+
+it('calculates depths', () => {
+
+  [1, 2, 3].forEach((n) => {
+    const orgData = require('./depth-' + n + '.json');
+    const model = OrganizationModel.fromPersistence(orgData, () => null);
+
+    expect(org.calcDepth(model.sequences.children.first() as contentTypes.Sequence)).toBe(+n);
+  });
+
+});
+
+
+it('finds the parent container', () => {
+
+  const orgData = require('./depth-3.json');
+  const model = OrganizationModel.fromPersistence(orgData, () => null);
+
+  let node = org.findContainerOrParent(model, Maybe.just('section'));
+  expect(node.id).toBe('section');
+
+  node = org.findContainerOrParent(model, Maybe.just('page'));
+  expect(node.id).toBe('section');
+
+});
+
+
+it('can insert a child', () => {
+
+  const orgData = require('./depth-3.json');
+  const model = OrganizationModel.fromPersistence(orgData, () => null);
+
+  const node = org.findContainerOrParent(model, Maybe.just('section'));
+
+  const item = new contentTypes.Include({ id: 'include' });
+  const updated = org.insertAsChild(model, node, item);
+
+  const section = org.findContainerOrParent(updated, Maybe.just('include'));
+  expect(section.id).toBe('section');
+
+});
+
+
+
+it('does not translates modules to units', () => {
+
+  const orgData = require('./depth-2.json');
+  const model = OrganizationModel.fromPersistence(orgData, () => null);
+
+  const updated = org.translateModulesToUnits(model);
+
+  let moduleCount = 0;
+  let unitCount = 0;
+
+  map((e) => {
+    if (e.contentType === 'Unit') {
+      unitCount += 1;
+    }
+    if (e.contentType === 'Module') {
+      moduleCount += 1;
+    }
+    return e;
+  }, updated as any);
+
+  expect(moduleCount).toBe(1);
+  expect(unitCount).toBe(0);
+
+});
+
+it('translates modules to units and sections to modules', () => {
+
+  const orgData = require('./depth-3.json');
+  const model = OrganizationModel.fromPersistence(orgData, () => null);
+
+  const updated = org.translateModulesToUnits(model);
+
+  let moduleCount = 0;
+  let unitCount = 0;
+  let sectionCount = 0;
+
+  map((e) => {
+    if (e.contentType === 'Unit') {
+      unitCount += 1;
+    }
+    if (e.contentType === 'Module') {
+      moduleCount += 1;
+    }
+    if (e.contentType === 'Section') {
+      sectionCount += 1;
+    }
+    return e;
+  }, updated as any);
+
+  expect(moduleCount).toBe(1);
+  expect(unitCount).toBe(1);
+  expect(sectionCount).toBe(0);
+
+});

--- a/test/data/models/utils/depth-1.json
+++ b/test/data/models/utils/depth-1.json
@@ -1,0 +1,90 @@
+{
+  "rev": 22,
+  "guid": "2c928089687c978a016880028d0802f3",
+  "id": "math-h2e3n77d-1.0_default",
+  "type": "x-oli-organization",
+  "title": "Default Organization",
+  "shortTitle": null,
+  "lastRevision": {
+    "rev": 0,
+    "guid": "d98f2aeaa7ba404aae91d6d690dba5d3",
+    "revisionNumber": 17,
+    "previousRevision": "2b5091113974410b90c9c9cf93173ccc",
+    "md5": "3bb097cc20247872debfce4e8e6ea83f",
+    "author": "manager",
+    "revisionType": "SYSTEM",
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "lastSession": "93be13b78ad9465ca894504bcd201024",
+  "metadata": {
+    "jsonObject": {
+      "version": "1.0"
+    }
+  },
+  "dateCreated": "Jan 24, 2019 1:17:58 PM",
+  "dateUpdated": "Jan 25, 2019 10:16:08 PM",
+  "resourceState": "ACTIVE",
+  "fileNode": {
+    "rev": 0,
+    "guid": "2c928089687c978a01688715a11710fc",
+    "pathTo": "organizations/default/organization.json",
+    "pathFrom": "organizations/default/organization.xml",
+    "fileName": "organization.xml",
+    "mimeType": "application/json",
+    "fileSize": 0,
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "doc": {
+    "organization": {
+      "@id": "math-h2e3n77d-1.0_default",
+      "#array": [
+        {
+          "title": {
+            "#text": "Default Organization"
+          }
+        },
+        {
+          "description": {
+            "#text": "Sample organization included with the OLI project template."
+          }
+        },
+        {
+          "audience": {
+            "#text": "This organization is intended as an example for OLI content authors."
+          }
+        },
+        {
+          "labels": {
+            "@unit": "Unit",
+            "@module": "Module",
+            "@section": "Section",
+            "@sequence": "Sequence"
+          }
+        },
+        {
+          "sequences": {
+            "#array": [
+              {
+                "sequence": {
+                  "@id": "sequence1",
+                  "#array": [
+                    {
+                      "title": {
+                        "#text": "Project Template"
+                      }
+                    }
+                  ],
+                  "@audience": "all",
+                  "@category": "content"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "@version": "1.0"
+    }
+  }
+}

--- a/test/data/models/utils/depth-2.json
+++ b/test/data/models/utils/depth-2.json
@@ -1,0 +1,115 @@
+{
+  "rev": 22,
+  "guid": "2c928089687c978a016880028d0802f3",
+  "id": "math-h2e3n77d-1.0_default",
+  "type": "x-oli-organization",
+  "title": "Default Organization",
+  "shortTitle": null,
+  "lastRevision": {
+    "rev": 0,
+    "guid": "d98f2aeaa7ba404aae91d6d690dba5d3",
+    "revisionNumber": 17,
+    "previousRevision": "2b5091113974410b90c9c9cf93173ccc",
+    "md5": "3bb097cc20247872debfce4e8e6ea83f",
+    "author": "manager",
+    "revisionType": "SYSTEM",
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "lastSession": "93be13b78ad9465ca894504bcd201024",
+  "metadata": {
+    "jsonObject": {
+      "version": "1.0"
+    }
+  },
+  "dateCreated": "Jan 24, 2019 1:17:58 PM",
+  "dateUpdated": "Jan 25, 2019 10:16:08 PM",
+  "resourceState": "ACTIVE",
+  "fileNode": {
+    "rev": 0,
+    "guid": "2c928089687c978a01688715a11710fc",
+    "pathTo": "organizations/default/organization.json",
+    "pathFrom": "organizations/default/organization.xml",
+    "fileName": "organization.xml",
+    "mimeType": "application/json",
+    "fileSize": 0,
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "doc": {
+    "organization": {
+      "@id": "math-h2e3n77d-1.0_default",
+      "#array": [
+        {
+          "title": {
+            "#text": "Default Organization"
+          }
+        },
+        {
+          "description": {
+            "#text": "Sample organization included with the OLI project template."
+          }
+        },
+        {
+          "audience": {
+            "#text": "This organization is intended as an example for OLI content authors."
+          }
+        },
+        {
+          "labels": {
+            "@unit": "Unit",
+            "@module": "Module",
+            "@section": "Section",
+            "@sequence": "Sequence"
+          }
+        },
+        {
+          "sequences": {
+            "#array": [
+              {
+                "sequence": {
+                  "@id": "sequence1",
+                  "#array": [
+                    {
+                      "title": {
+                        "#text": "Project Template"
+                      }
+                    },
+                    {
+                      "module": {
+                        "@id": "lesson1",
+                        "#array": [
+                          {
+                            "title": {
+                              "#text": "Lesson 1"
+                            }
+                          },
+                          {
+                            "item": {
+                              "@id": "d1146946467745eda151e488f0cf4134",
+                              "#array": [
+                                {
+                                  "resourceref": {
+                                    "@idref": "a281e4f0165a4d819560b60b3b16c83d"
+                                  }
+                                }
+                              ],
+                              "@scoring_mode": "default"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "@audience": "all",
+                  "@category": "content"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "@version": "1.0"
+    }
+  }
+}

--- a/test/data/models/utils/depth-3.json
+++ b/test/data/models/utils/depth-3.json
@@ -1,0 +1,129 @@
+{
+  "rev": 22,
+  "guid": "2c928089687c978a016880028d0802f3",
+  "id": "math-h2e3n77d-1.0_default",
+  "type": "x-oli-organization",
+  "title": "Default Organization",
+  "shortTitle": null,
+  "lastRevision": {
+    "rev": 0,
+    "guid": "d98f2aeaa7ba404aae91d6d690dba5d3",
+    "revisionNumber": 17,
+    "previousRevision": "2b5091113974410b90c9c9cf93173ccc",
+    "md5": "3bb097cc20247872debfce4e8e6ea83f",
+    "author": "manager",
+    "revisionType": "SYSTEM",
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "lastSession": "93be13b78ad9465ca894504bcd201024",
+  "metadata": {
+    "jsonObject": {
+      "version": "1.0"
+    }
+  },
+  "dateCreated": "Jan 24, 2019 1:17:58 PM",
+  "dateUpdated": "Jan 25, 2019 10:16:08 PM",
+  "resourceState": "ACTIVE",
+  "fileNode": {
+    "rev": 0,
+    "guid": "2c928089687c978a01688715a11710fc",
+    "pathTo": "organizations/default/organization.json",
+    "pathFrom": "organizations/default/organization.xml",
+    "fileName": "organization.xml",
+    "mimeType": "application/json",
+    "fileSize": 0,
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "doc": {
+    "organization": {
+      "@id": "math-h2e3n77d-1.0_default",
+      "#array": [
+        {
+          "title": {
+            "#text": "Default Organization"
+          }
+        },
+        {
+          "description": {
+            "#text": "Sample organization included with the OLI project template."
+          }
+        },
+        {
+          "audience": {
+            "#text": "This organization is intended as an example for OLI content authors."
+          }
+        },
+        {
+          "labels": {
+            "@unit": "Unit",
+            "@module": "Module",
+            "@section": "Section",
+            "@sequence": "Sequence"
+          }
+        },
+        {
+          "sequences": {
+            "@id": "sequences",
+            "#array": [
+              {
+                "sequence": {
+                  "@id": "sequence1",
+                  "#array": [
+                    {
+                      "title": {
+                        "#text": "Project Template"
+                      }
+                    },
+                    {
+                      "module": {
+                        "@id": "lesson1",
+                        "#array": [
+                          {
+                            "title": {
+                              "#text": "Lesson 1"
+                            }
+                          },
+                          {
+                            "section": {
+                              "@id": "section",
+                              "#array": [
+                                {
+                                  "title": {
+                                    "#text": "Lesson 1"
+                                  }
+                                },
+                                {
+                                  "item": {
+                                    "@id": "page",
+                                    "#array": [
+                                      {
+                                        "resourceref": {
+                                          "@idref": "a281e4f0165a4d819560b60b3b16c83d"
+                                        }
+                                      }
+                                    ],
+                                    "@scoring_mode": "default"
+                                  }
+                                }
+                              ],
+                              "@scoring_mode": "default"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "@audience": "all",
+                  "@category": "content"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "@version": "1.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds org manipulation support for adding 'containers' - where a 'container' is either a sequence, unit, module or section.  The type of container added is determined by the internal logic of the add container routines and is based on the location of where the container is being added.

RISK: Low, unused at the moment, isolated to org changing once it is used
STABILITY: Medium/High, decent unit test coverage