### PR TITLE
fix link click error

### DIFF
--- a/src/components/OrgLibrary.tsx
+++ b/src/components/OrgLibrary.tsx
@@ -86,9 +86,7 @@ export default class OrgLibrary extends React.Component<OrgLibraryProps, OrgLibr
         = 'list-group-item list-group-item-action align-items-start flex-column';
       const since = relativeToNow(org.dateUpdated);
 
-      const onClick = thisId === currentOrgId
-        ? undefined
-        : (e) => { e.preventDefault(); this.props.onSelectOrg(thisId); };
+      const onClick = (e) => { e.preventDefault(); this.props.onSelectOrg(thisId); };
 
       return (
         <li


### PR DESCRIPTION
This PR fixes the problem of clicking on the active org in the org library and it routing the user back to the main view.

Fix was to ensure a valid handler was in place, instead of 'undefined'.

RISK: Low, isolated to org library
STABILITY: High, tested and fixes the problem