### PR TITLE
avoid connected decorator

### DIFF
--- a/src/data/content/learning/draft/todraft.ts
+++ b/src/data/content/learning/draft/todraft.ts
@@ -409,8 +409,8 @@ function processInline(
     // This special case below checks for the latter case and appends
     // two spaces that will be necessary to display up to two-digit long
     // bibliography entry when rendered
-    if (key === 'cite' && text.length === 0) {
-      blockContext.fullText += '  ';
+    if (key === 'cite' && (text.length === 0 || text === ' ')) {
+      blockContext.fullText += (text.length === 0) ? '  ' : ' ';
       text = blockContext.fullText.substring(offset);
     }
 

--- a/src/editors/content/common/AbstractContentEditor.tsx
+++ b/src/editors/content/common/AbstractContentEditor.tsx
@@ -38,6 +38,7 @@ export interface AbstractContentEditorProps<ModelType> {
   // through non CTE elements (like a Table) to child CTEs.
   onEntitySelected?: (key: string, data: Object) => void;
   selectedEntity?: Maybe<string>;
+
 }
 
 export interface AbstractContentEditorState { }

--- a/src/editors/content/common/RichTextEditor.tsx
+++ b/src/editors/content/common/RichTextEditor.tsx
@@ -43,20 +43,21 @@ export class RichTextEditor
     return null;
   }
 
-  renderMain() : JSX.Element {
+  renderMain(): JSX.Element {
 
     const editor = <ContiguousTextEditor
-            onInsertParsedContent={() => {}}
-            activeContentGuid={null}
-            hover={null}
-            onUpdateHover={() => {}}
-            onFocus={this.props.onFocus}
-            context={this.props.context}
-            services={this.props.services}
-            editMode={this.props.editMode}
-            model={this.props.model}
-            onEdit={this.onEdit}
-            />;
+      onInsertParsedContent={() => { }}
+      activeContentGuid={null}
+      hover={null}
+      orderedIds={null}
+      onUpdateHover={() => { }}
+      onFocus={this.props.onFocus}
+      context={this.props.context}
+      services={this.props.services}
+      editMode={this.props.editMode}
+      model={this.props.model}
+      onEdit={this.onEdit}
+    />;
 
     const display = this.props.showLabel === undefined || this.props.showLabel
       ? <InputLabel label={this.props.label} style="default">

--- a/src/editors/content/common/draft/DraftWrapper.tsx
+++ b/src/editors/content/common/draft/DraftWrapper.tsx
@@ -37,6 +37,7 @@ export interface DraftWrapperProps {
   onInsertParsedContent: (content: ParsedContent) => void;
   onEntitySelected?: (key: string, data: Object) => void;
   selectedEntity?: Maybe<string>;
+  orderedIds: Immutable.Map<string, number>;
 }
 
 interface DraftWrapperState {
@@ -290,12 +291,16 @@ class DraftWrapper extends React.Component<DraftWrapperProps, DraftWrapperState>
     if (this.props.selectedEntity !== nextProps.selectedEntity) {
       return true;
     }
+    if (this.props.orderedIds !== nextProps.orderedIds) {
+      return true;
+    }
     return false;
   }
 
   componentWillReceiveProps(nextProps: DraftWrapperProps) {
 
-    if (this.props.selectedEntity !== nextProps.selectedEntity) {
+    if (this.props.selectedEntity !== nextProps.selectedEntity
+      || this.props.orderedIds !== nextProps.orderedIds) {
       this.lastContent = nextProps.content.content;
       const es = EditorState.createWithContent(
         nextProps.content.content,
@@ -359,6 +364,7 @@ class DraftWrapper extends React.Component<DraftWrapperProps, DraftWrapperState>
       props.onSelectionChange(ss, true);
     };
     const compositeDecorator = buildCompositeDecorator({
+      orderedIds: props.orderedIds,
       selectedEntity: props.selectedEntity,
       services: props.services,
       context: props.context, onEdit: onDecoratorEdit,

--- a/src/editors/content/common/draft/decorators/Cite.tsx
+++ b/src/editors/content/common/draft/decorators/Cite.tsx
@@ -33,7 +33,7 @@ class Cite extends React.Component<{ orderedIds, entityKey, offsetKey, contentSt
 
     if (entry !== '') {
 
-      let position = this.props.orderedIds.has(entry)
+      let position = this.props.orderedIds !== undefined && this.props.orderedIds.has(entry)
         ? this.props.orderedIds.get(entry) + 1
         : '  ';
       if ((position + '').length === 1) {
@@ -49,36 +49,10 @@ class Cite extends React.Component<{ orderedIds, entityKey, offsetKey, contentSt
 }
 
 
-interface StateProps {
-  orderedIds: Immutable.Map<string, number>;
-}
-
-interface DispatchProps {
-
-}
-
-interface OwnProps { }
-
-const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => {
-
-  const { orderedIds } = state;
-
-  return {
-    orderedIds,
-  };
-};
-
-const mapDispatchToProps = (dispatch: Dispatch<State>, ownProps: OwnProps): DispatchProps => {
-  return {};
-};
-
-const CiteController = connect<StateProps, DispatchProps, OwnProps>
-  (mapStateToProps, mapDispatchToProps)(Cite);
-
 export default function (props: Object): Decorator {
   return {
     strategy: byType.bind(undefined, EntityTypes.cite),
-    component: CiteController,
+    component: Cite,
     props,
   };
 }

--- a/src/editors/content/learning/blockcode/BlockCodeEditor.tsx
+++ b/src/editors/content/learning/blockcode/BlockCodeEditor.tsx
@@ -55,6 +55,7 @@ class BlockCodeEditor
         <ContiguousTextEditor
           {...this.props}
           onInsertParsedContent={() => { }}
+          orderedIds={null}
           onFocus={this.onFocusOverride}
           model={this.props.model.text}
           onEdit={this.onEditText}

--- a/src/editors/content/learning/blockformula/BlockFormulaEditor.tsx
+++ b/src/editors/content/learning/blockformula/BlockFormulaEditor.tsx
@@ -19,9 +19,9 @@ export interface BlockFormulaEditorState {
 }
 
 class BlockFormulaEditor
-    extends AbstractContentEditor
-    <contentTypes.BlockFormula, StyledComponentProps<BlockFormulaEditorProps, typeof styles>,
-    BlockFormulaEditorState> {
+  extends AbstractContentEditor
+  <contentTypes.BlockFormula, StyledComponentProps<BlockFormulaEditorProps, typeof styles>,
+  BlockFormulaEditorState> {
 
   constructor(props) {
     super(props);
@@ -55,7 +55,8 @@ class BlockFormulaEditor
         <div className={classes.formulaWrapper}>
           <ContiguousTextEditor
             {...this.props}
-            onInsertParsedContent={() => {}}
+            onInsertParsedContent={() => { }}
+            orderedIds={null}
             onFocus={this.onFocusOverride}
             model={this.props.model.text}
             onEdit={this.onEditText}>

--- a/src/editors/content/learning/blockquote/BlockQuoteEditor.tsx
+++ b/src/editors/content/learning/blockquote/BlockQuoteEditor.tsx
@@ -20,9 +20,9 @@ export interface BlockQuoteEditorState {
 }
 
 class BlockQuoteEditor
-    extends AbstractContentEditor
-    <contentTypes.BlockQuote, StyledComponentProps<BlockQuoteEditorProps, typeof styles>,
-    BlockQuoteEditorState> {
+  extends AbstractContentEditor
+  <contentTypes.BlockQuote, StyledComponentProps<BlockQuoteEditorProps, typeof styles>,
+  BlockQuoteEditorState> {
 
   constructor(props) {
     super(props);
@@ -56,7 +56,8 @@ class BlockQuoteEditor
         <div className={classes.quoteWrapper}>
           <ContiguousTextEditor
             {...this.props}
-            onInsertParsedContent={() => {}}
+            onInsertParsedContent={() => { }}
+            orderedIds={null}
             onFocus={this.onFocusOverride}
             model={this.props.model.text}
             onEdit={this.onEditText}>

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
@@ -1,10 +1,11 @@
+import * as Immutable from 'immutable';
 import { connect } from 'react-redux';
 import ContiguousTextEditor from './ContiguousTextEditor';
 import { insertParsedContent } from 'actions/active';
 import { ParsedContent } from 'data/parsers/common/types';
 
 interface StateProps {
-
+  orderedIds: Immutable.Map<string, number>;
 }
 
 interface DispatchProps {
@@ -16,7 +17,9 @@ interface OwnProps {
 }
 
 const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
-  return {};
+  return {
+    orderedIds: state.orderedIds,
+  };
 };
 
 const mapDispatchToProps = (dispatch, getState): DispatchProps => {
@@ -24,11 +27,11 @@ const mapDispatchToProps = (dispatch, getState): DispatchProps => {
   return {
     onInsertParsedContent: (
       resourcePath: string, content: ParsedContent) =>
-        dispatch(insertParsedContent(resourcePath, content)),
+      dispatch(insertParsedContent(resourcePath, content)),
   };
 };
 
 export const controller = connect<StateProps, DispatchProps, OwnProps>
-(mapStateToProps, mapDispatchToProps)(ContiguousTextEditor);
+  (mapStateToProps, mapDispatchToProps)(ContiguousTextEditor);
 
 export { controller as ContiguousTextEditor };

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as Immutable from 'immutable';
 import * as contentTypes from 'data/contentTypes';
 import { withStyles, classNames } from 'styles/jss';
 import { StyledComponentProps } from 'types/component';
@@ -22,7 +23,7 @@ export interface ContiguousTextEditorProps
   hideBorder?: boolean;
   onTextSelectionChange?: (selection: any) => void;
   onInsertParsedContent: (resourcePath: string, o) => void;
-
+  orderedIds: Immutable.Map<string, number>;
 }
 
 export interface ContiguousTextEditorState {
@@ -49,7 +50,8 @@ class ContiguousTextEditor
 
   shouldComponentUpdate(nextProps: StyledContiguousTextEditorProps) {
     return nextProps.model !== this.props.model
-      || nextProps.selectedEntity !== this.props.selectedEntity;
+      || nextProps.selectedEntity !== this.props.selectedEntity
+      || nextProps.orderedIds !== this.props.orderedIds;
   }
 
   renderActiveEntity(entity) {
@@ -115,6 +117,7 @@ class ContiguousTextEditor
           viewOnly && classes.viewOnly, className])}>
 
         <DraftWrapper
+          orderedIds={this.props.orderedIds}
           selectedEntity={this.props.selectedEntity}
           onEntitySelected={this.props.onEntitySelected}
           onInsertParsedContent={o =>

--- a/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.controller.ts
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.controller.ts
@@ -17,6 +17,7 @@ interface StateProps {
   selection: TextSelection;
   resource: Resource;
   courseModel: CourseModel;
+  orderedIds?: any;
 }
 
 interface DispatchProps {

--- a/src/editors/content/learning/contiguoustext/ContiguousTextViewer.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextViewer.tsx
@@ -18,23 +18,24 @@ export interface ContiguousTextViewerProps {
  */
 export const ContiguousTextViewer:
   React.StatelessComponent<ComponentProps<ContiguousTextViewerProps>> = (({
-  className, children, context, services, model, editorStyles,
-}) => {
+    className, context, services, model, editorStyles,
+  }) => {
     return (
       <div className={classNames([className])}>
         <ContiguousTextEditor
-          onInsertParsedContent={() => {}}
+          onInsertParsedContent={() => { }}
           activeContentGuid={null}
           hover={null}
-          onUpdateHover={() => {}}
-          onFocus={() => {}}
+          onUpdateHover={() => { }}
+          onFocus={() => { }}
           context={context}
+          orderedIds={null}
           services={services}
           editMode={false}
           model={model}
           editorStyles={editorStyles}
           viewOnly
-          onEdit={() => {}} />
+          onEdit={() => { }} />
       </div>
     );
   });

--- a/src/editors/content/learning/contiguoustext/TitleTextEditor.tsx
+++ b/src/editors/content/learning/contiguoustext/TitleTextEditor.tsx
@@ -47,6 +47,7 @@ export const TitleTextEditor
           editMode={editMode}
           model={(model as ContiguousText).with({ mode: ContiguousTextMode.SimpleText })}
           editorStyles={editorStyles}
+          orderedIds={null}
           hideBorder={true}
           onEdit={onEdit} />
         <div className={classes.editIcon}>


### PR DESCRIPTION
There were a couple of problems leading to this bug.  First and foremost, the Cite decorator was a Redux connected component.  We have found that something with the migration to React 16.8 has broken the ability for Draft decorators to be able to render correctly when they are a connected component.  I refactored to make the CTE parent component fetch the orderedIds state.

Second, the todraft.ts was not accounting for cite entries that contained a single space as their content.  

RISK: Low/Medium, in theory could introduce perf issues with rendering, does not seem to have
STABILITY: High, seems to fix the issue