### PR TITLE
remove CWRPs

### DIFF
--- a/src/components/sidebar/ContextAwareSidebar.tsx
+++ b/src/components/sidebar/ContextAwareSidebar.tsx
@@ -176,18 +176,10 @@ class ContextAwareSidebar
   componentDidMount() {
     this.fetchRefs(this.props);
   }
-  componentWillReceiveProps(nextProps: ContextAwareSidebarProps) {
-    if ((this.props.course.guid !== nextProps.course.guid)
-      || (this.props.resource.id !== nextProps.resource.id)) {
-      this.fetchRefs(nextProps);
-    }
-  }
 
   fetchRefs(props: ContextAwareSidebarProps) {
     const { course, resource } = props;
-    this.setState({
-      resourceRefs: Maybe.nothing(),
-    });
+
     persistence.fetchEdges(course.guid).then((edges) => {
 
       const sources = edges.filter((edge) => {


### PR DESCRIPTION
This fixes the flickering sidebar refs display.

All that was needed was to remove the CWRPs - the call to fetchRefs here never matters as anytime the course or resource changes the entire sidebar component is torn down and replaced

RISK: Low
STABILITY: High, fixes the problem