### PR TITLE
Authoring 2018 likert hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/content/feedback/likertseries/QuestionTable.tsx
+++ b/src/editors/content/feedback/likertseries/QuestionTable.tsx
@@ -27,7 +27,7 @@ export interface Props extends AbstractContentEditorProps<LikertSeries> {
   editMode: boolean;
   onEditScale: (scale: LikertScale, src: ContentElement) => void;
   onEditItems: (items: Immutable.OrderedMap<string, LikertItem>, src: ContentElement) => void;
-  allowGroup? : boolean; // controller by Toggle switch
+  allowGroup?: boolean; // controller by Toggle switch
 }
 
 export interface State { }
@@ -197,7 +197,7 @@ export class QuestionTable extends React.PureComponent<Props, State> {
       );
     };
 
-    const scaleOptions = [1, 3, 5, 7]
+    const scaleOptions = [1, 2, 3, 4, 5, 6, 7, 8]
       .map(n => <option key={n} value={n}>{n}</option>);
 
     return (
@@ -225,8 +225,8 @@ export class QuestionTable extends React.PureComponent<Props, State> {
                 </td>
               ))}
               {allowGroup ?
-              (<td>Group</td>) :
-              (null)}
+                (<td>Group</td>) :
+                (null)}
             </tr>
           </thead>
           <tbody>

--- a/src/editors/content/feedback/singlelikertquestion/LikertEditor.tsx
+++ b/src/editors/content/feedback/singlelikertquestion/LikertEditor.tsx
@@ -65,7 +65,7 @@ export class LikertEditor extends AbstractContentEditor<Likert, Props, State> {
   renderMain() {
     const { editMode, canRemove, onRemove, onDuplicate, model } = this.props;
 
-    const scaleOptions = [1, 3, 5, 7]
+    const scaleOptions = [1, 2, 3, 4, 5, 6, 7, 8]
       .map(n => <option key={n} value={n}>{n}</option>);
 
     return (


### PR DESCRIPTION
This PR reapplies likert even numbers as a hotfix.

RISK: Low
STABILITY: High - the backend PR has already landed to master as part of sprint 32. This simply restores the front-end piece that adds the options 