### PR TITLE
Fix error thrown sometimes on objective skill view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.32.5",
+  "version": "0.33.0",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/components/objectives/ObjectiveSkillView.tsx
+++ b/src/components/objectives/ObjectiveSkillView.tsx
@@ -296,7 +296,7 @@ class ObjectiveSkillView
   componentWillUpdate(
     nextProps: Readonly<ObjectiveSkillViewProps>, nextState: Readonly<ObjectiveSkillViewState>) {
 
-    const obj = this.props.selectedOrganization.caseOf({
+    const org = this.props.selectedOrganization.caseOf({
       just: o => o,
       nothing: () => null,
     });
@@ -305,10 +305,10 @@ class ObjectiveSkillView
     if (nextState.aggregateModel !== null
       && nextState.aggregateModel !== this.state.aggregateModel) {
 
-      this.fetchAllRefs(this.props.skills, nextState.objectives, obj);
+      this.fetchAllRefs(this.props.skills, nextState.objectives, org);
 
     } else if (this.state.aggregateModel !== null && nextProps.skills !== this.props.skills) {
-      this.fetchAllRefs(nextProps.skills, this.state.objectives, obj);
+      this.fetchAllRefs(nextProps.skills, this.state.objectives, org);
     }
   }
 
@@ -339,7 +339,9 @@ class ObjectiveSkillView
   ) {
     const { course } = this.props;
 
-    const directResources = org.getFlattenedResources().toArray();
+    const directResources = org
+      ? org.getFlattenedResources().toArray()
+      : [];
     const directLookup = Immutable.Set<string>(directResources);
 
 


### PR DESCRIPTION
**Business need**: Some users in summer school were seeing the frowny face on the objective skill view page because of the `getFlattenedResources` method.
**Solution**: I'm not sure what the root cause is, but it seems like the `selectedOrganization` is sometimes undefined if it's not set in redux before the component is loaded. This should at least prevent the page from throwing.
**Wireframe**: None
**Risk**: Low
**Areas of concern**: Only the objective skill view editor changed