### PR TITLE
Add team members description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.32.5",
+  "version": "0.33.0",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/document/course/CourseEditor.tsx
+++ b/src/editors/document/course/CourseEditor.tsx
@@ -330,7 +330,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
     return (
       <React.Fragment>
         <div style={{ marginBottom: 10 }}>
-          You can add your team members here to grant them access to this course.
+          You can add your team members here to allow them to edit this course.
         </div>
         <label htmlFor="team"
           style={{ color: '#aaa', fontWeight: 600, fontSize: '0.9rem', marginBottom: 0 }}>
@@ -834,7 +834,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
                       <React.Fragment>
                         Analytics for this course are based on the latest dataset, which was created
                       {' '}<b>{dateFormatted(parseDate(dataSet.dateCreated))}</b>.
-                          To get the most recent data for analytics, create a new dataset.
+                            To get the most recent data for analytics, create a new dataset.
                         <br />
                         <br />
                         <b>Notice:</b> Dataset creation may take a few minutes depending on the size

--- a/src/editors/document/course/CourseEditor.tsx
+++ b/src/editors/document/course/CourseEditor.tsx
@@ -834,8 +834,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
                       <React.Fragment>
                         Analytics for this course are based on the latest dataset, which was created
                       {' '}<b>{dateFormatted(parseDate(dataSet.dateCreated))}</b>.
-                                                                            To get the most recent
-                                                                            data for analytics, create a new dataset.
+                          To get the most recent data for analytics, create a new dataset.
                         <br />
                         <br />
                         <b>Notice:</b> Dataset creation may take a few minutes depending on the size

--- a/src/editors/document/course/CourseEditor.tsx
+++ b/src/editors/document/course/CourseEditor.tsx
@@ -328,15 +328,25 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
     const developers = this.props.model.developers.toArray();
 
     return (
-      <Typeahead
-        disabled={!this.props.editMode}
-        multiple
-        renderMenuItemChildren={this.onRenderMenuItemChildren}
-        onChange={this.onEditDevelopers}
-        options={developers}
-        labelKey={(d: UserInfo) => `${d.firstName} ${d.lastName} (${d.email})`}
-        selected={this.state.selectedDevelopers}
-      />
+      <React.Fragment>
+        <div style={{ marginBottom: 10 }}>
+          You can add your team members here to grant them access to this course.
+        </div>
+        <label htmlFor="team"
+          style={{ color: '#aaa', fontWeight: 600, fontSize: '0.9rem', marginBottom: 0 }}>
+          Enter a user's name or email...
+        </label>
+        <Typeahead
+          inputProps={{ id: 'team' }}
+          disabled={!this.props.editMode}
+          multiple
+          renderMenuItemChildren={this.onRenderMenuItemChildren}
+          onChange={this.onEditDevelopers}
+          options={developers}
+          labelKey={(d: UserInfo) => `${d.firstName} ${d.lastName} (${d.email})`}
+          selected={this.state.selectedDevelopers}
+        />
+      </React.Fragment>
     );
   }
 
@@ -824,8 +834,8 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
                       <React.Fragment>
                         Analytics for this course are based on the latest dataset, which was created
                       {' '}<b>{dateFormatted(parseDate(dataSet.dateCreated))}</b>.
-                                          To get the most recent
-                                          data for analytics, create a new dataset.
+                                                                            To get the most recent
+                                                                            data for analytics, create a new dataset.
                         <br />
                         <br />
                         <b>Notice:</b> Dataset creation may take a few minutes depending on the size


### PR DESCRIPTION
**Business need**: We received feedback from multiple people in the summer session that it was difficult to figure out what the **Team members** field on the course package home page was for and how to add users. 
**Solution**: A description above the typeahead component should help out.
**Wireframe**: None
**Risk**: Very low
**Areas of concern**: None, only a text change