### PR TITLE
Prevent hotspots from being created outside of the allowed area

### DIFF
--- a/src/editors/content/question/imagehotspot/CircleEditor.tsx
+++ b/src/editors/content/question/imagehotspot/CircleEditor.tsx
@@ -36,8 +36,8 @@ export interface CircleEditorState {
  * CircleEditor React Component
  */
 class CircleEditor
-    extends React.PureComponent<StyledComponentProps<CircleEditorProps, typeof styles>,
-    CircleEditorState> {
+  extends React.PureComponent<StyledComponentProps<CircleEditorProps, typeof styles>,
+  CircleEditorState> {
 
   constructor(props) {
     super(props);
@@ -186,9 +186,9 @@ class CircleEditor
           // ensure new location is inside the hotspot area
           calculatedCoords = {
             cx: Math.min(
-              Math.max(calculatedCoords.cx, 0), boundingClient.width),
+              Math.max(calculatedCoords.cx, 0 + radius), boundingClient.width - radius),
             cy: Math.min(
-              Math.max(calculatedCoords.cy, 0), boundingClient.height),
+              Math.max(calculatedCoords.cy, 0 + radius), boundingClient.height - radius),
           };
 
           this.setState({

--- a/src/editors/content/question/imagehotspot/RectangleEditor.tsx
+++ b/src/editors/content/question/imagehotspot/RectangleEditor.tsx
@@ -209,17 +209,11 @@ class RectangleEditor
           };
 
           // ensure new location is inside the hotspot area
-          const halfWidth = Math.floor(width / 2);
-          const halfHeight = Math.floor(height / 2);
           calculatedCoords = {
-            x1: Math.min(
-              Math.max(calculatedCoords.x1, 0 - halfWidth), (boundingClient.width - halfWidth)),
-            y1: Math.min(
-              Math.max(calculatedCoords.y1, 0 - halfHeight), (boundingClient.height - halfHeight)),
-            x2: Math.min(
-              Math.max(calculatedCoords.x2, halfWidth), boundingClient.width + halfWidth),
-            y2: Math.min(
-              Math.max(calculatedCoords.y2, halfHeight), boundingClient.height + halfHeight),
+            x1: Math.min(Math.max(calculatedCoords.x1, 0), boundingClient.width - 5),
+            y1: Math.min(Math.max(calculatedCoords.y1, 0), boundingClient.height - 5),
+            x2: Math.min(Math.max(calculatedCoords.x2, 0) + 5, boundingClient.width),
+            y2: Math.min(Math.max(calculatedCoords.y2, 0) + 5, boundingClient.height),
           };
 
           this.setState({


### PR DESCRIPTION
**Business need**: Hotspots can be dragged outside of the allowable area in the editor, leading to course errors on publish. Users ran into this during learnlab
**Solution**: Constrain both the circle and rectangle hotspots within the editable "field" so they can't have edges outside of the allowed area
**Wireframe**: None
**Risk**: Low
**Areas of concern**: None, only affects image hotspot questions. Tested on shattrath by full-previewing courses after trying to move both rectangle and circle hotspots outside of the allowed area in each corner.