### PR TITLE
Limit package id and org id lengths

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -255,9 +255,11 @@ export default class Main extends React.Component<MainProps, MainState> {
 
 const createOrg = (courseGuid: CourseGuid, title, courseTitle: string, wbId: string) => {
   const g = guid();
-  const id = courseGuid.value() + '_' +
+  const id = (courseGuid.value() + '_' +
     title.toLowerCase().split(' ')[0] + '_'
-    + g.substring(g.lastIndexOf('-') + 1);
+    + g.substring(g.lastIndexOf('-') + 1))
+    // slice to prevent id size errors in db
+    .slice(0, 40);
 
   const prefix = courseTitle.toLowerCase().startsWith('Welcome')
     ? '' : 'Welcome to ';

--- a/src/components/CreateCourseView.tsx
+++ b/src/components/CreateCourseView.tsx
@@ -41,8 +41,7 @@ class CreateCourseView extends React.PureComponent<CreateCourseViewProps, Create
       .replace(/[\W_]+/g, '')
       // slice to prevent id size errors in db
       .slice(0, 16)
-      + '-' + g.substring(g.lastIndexOf('-') + 1))
-      .slice(0, 20);
+      + '-' + g.substring(g.lastIndexOf('-') + 1));
 
     const model = new models.CourseModel({
       guid: CourseGuid.of(g), id, title, version: '1.0', idvers: CourseIdVers.of(id, '1.0'),
@@ -94,7 +93,7 @@ class CreateCourseView extends React.PureComponent<CreateCourseViewProps, Create
         title="What's your course called?"
         placeholder="e.g. Introduction to Psychology, Spanish I"
         buttonLabel="Create Course"
-        submitted={this.state.waiting}
+        submitted={this.state.error || this.state.waiting}
         toast={this.state.waiting
           ? waiting
           : this.state.error

--- a/src/components/CreateCourseView.tsx
+++ b/src/components/CreateCourseView.tsx
@@ -36,7 +36,14 @@ class CreateCourseView extends React.PureComponent<CreateCourseViewProps, Create
 
   startCreation(title: string) {
     const g = guid();
-    const id = title.toLowerCase().split(' ')[0] + '-' + g.substring(g.lastIndexOf('-') + 1);
+    const id = (title.toLowerCase().split(' ')[0]
+      // replace non-alphanumberic chars
+      .replace(/[\W_]+/g, '')
+      // slice to prevent id size errors in db
+      .slice(0, 16)
+      + '-' + g.substring(g.lastIndexOf('-') + 1))
+      .slice(0, 20);
+
     const model = new models.CourseModel({
       guid: CourseGuid.of(g), id, title, version: '1.0', idvers: CourseIdVers.of(id, '1.0'),
     });
@@ -87,7 +94,7 @@ class CreateCourseView extends React.PureComponent<CreateCourseViewProps, Create
         title="What's your course called?"
         placeholder="e.g. Introduction to Psychology, Spanish I"
         buttonLabel="Create Course"
-        submitted={this.state.error || this.state.waiting}
+        submitted={this.state.waiting}
         toast={this.state.waiting
           ? waiting
           : this.state.error


### PR DESCRIPTION
**Business Need**: If a user creates a new course with a title that has a long first word, resources that use the course ID will cause DB errors when saved. This has been seen multiple times when creating new organizations, which create IDs based on the course ID.
**Solution**: 
1) When creating courses, slice the length of the first word in the title that's used to create the package ID to 16 characters, then append the unique GUID to the ID.

Also remove non-alphanumeric characters from the title when creating the ID.

2) Slice the length of new organization IDs to 40 chars.

These lengths are conservative (resource IDs can be up to about 60 chars in total), but longer IDs don't really serve much of a purpose beyond ensuring uniqueness, which isn't an issue when resource IDs only need to be unique within a course. The shorter length just makes the IDs easier to read.

_Note_: I fixed a separate bug where the "create course" button wouldn't reset if a course failed to be created.

**Wireframe / Screenshot if UI work**: None
**Risk**: Medium, only triggered on course and organization creation.
**Areas of concern**: None.
