### PR TITLE
Fix assessment rendering when toggling branching assessment

### DIFF
--- a/src/components/sidebar/ContextAwareSidebar.controller.ts
+++ b/src/components/sidebar/ContextAwareSidebar.controller.ts
@@ -12,7 +12,7 @@ import { Resource } from 'data/content/resource';
 import { AppContext } from 'editors/common/AppContext';
 import { AppServices } from 'editors/common/AppServices';
 import { ContentElement } from 'data/content/common/interfaces';
-import { ContentModel, CourseModel, Node, ModelTypes, OrganizationModel } from 'data/models';
+import { ContentModel, Node, OrganizationModel } from 'data/models';
 import { modalActions } from 'actions/modal';
 import { CombinationsMap } from 'types/combinations';
 import { computeCombinations } from 'actions/choices';

--- a/src/components/sidebar/ContextAwareSidebar.tsx
+++ b/src/components/sidebar/ContextAwareSidebar.tsx
@@ -181,16 +181,16 @@ class ContextAwareSidebar
     const { course, resource } = props;
 
     persistence.fetchEdges(course.guid).then((edges) => {
- // returns a list of edges pointing to the current page, with no edges sharing the same source
+      // returns a list of edges pointing to the current page, with no edges sharing the same source
       const sources: Edge[] = edges.filter(edge => this.stripId(edge.destinationId) === resource.id)
-      .reduce((prev : {usedResources: any, edges: Edge[]}, edge) => {
-        if (prev.usedResources[edge.sourceId]) {
+        .reduce((prev: { usedResources: any, edges: Edge[] }, edge) => {
+          if (prev.usedResources[edge.sourceId]) {
+            return prev;
+          }
+          prev.usedResources[edge.sourceId] = edge;
+          prev.edges.push(edge);
           return prev;
-        }
-        prev.usedResources[edge.sourceId] = edge;
-        prev.edges.push(edge);
-        return prev;
-      }, { usedResources: {}, edges: [] }).edges;
+        }, { usedResources: {}, edges: [] }).edges;
 
       this.setState({
         resourceRefs: Maybe.just(sources),
@@ -255,9 +255,14 @@ class ContextAwareSidebar
   }
 
   onToggleBranching() {
-    const { model, onEditModel, onDisplayModal, onDismissModal } = this.props;
+    const { model, onEditModel, onDisplayModal, onDismissModal, onSetCurrentNodeOrPage,
+      resource } = this.props;
 
-    const toggleBranching = (model: AssessmentModel) => onEditModel(model);
+    const toggleBranching = (model: AssessmentModel) => {
+      onEditModel(model);
+      const firstPage = model.pages.first() && model.pages.first().guid;
+      onSetCurrentNodeOrPage(resource.id, firstPage);
+    };
 
     const assessmentModel = model as AssessmentModel;
     const newModel = assessmentModel.with({
@@ -354,47 +359,47 @@ class ContextAwareSidebar
 
                       {
                         refs.map(ref => getRefResourceFromRef(ref))
-                        .filter(res => res !== undefined &&
-                                       res.resourceState !== ResourceState.DELETED)
-                        .sort((a, b) => {
-                          if (a.type === b.type) {
-                            return (a.title < b.title ? -1 : 1);
-                          }
-                          if (a.type === 'x-oli-organization') {
-                            return -1;
-                          }
-                          if (b.type === 'x-oli-organization') {
-                            return 1;
-                          }
-                          if (a.type === 'x-oli-workbook_page') {
-                            return -1;
-                          }
-                          if (b.type === 'x-oli-workbook_page') {
-                            return 1;
-                          }
-                          return 0;
-                        })
-                        .map(res => (
-                          <div key={res.guid} className="ref-thing">
-                            <a href="#" onClick={(event) => {
-                              event.preventDefault();
-                              // if link is to org, just switch org and stay on current page
-                              if (res.type === 'x-oli-organization') {
-                                viewDocument(resource.id, course.idvers,
-                                  Maybe.maybe(res.id));
-                              } else {
-                                viewDocument(res.id, course.idvers, Maybe.nothing());
-                              }
+                          .filter(res => res !== undefined &&
+                            res.resourceState !== ResourceState.DELETED)
+                          .sort((a, b) => {
+                            if (a.type === b.type) {
+                              return (a.title < b.title ? -1 : 1);
                             }
-                            }>
-                              <span style={{ width: 26, textAlign: 'center', marginRight: 5 }}>
-                                {
-                                  getNameAndIconByType(res.type).icon}
-                              </span>
-                              {res.title}
-                            </a>
-                          </div>
-                        ))}
+                            if (a.type === 'x-oli-organization') {
+                              return -1;
+                            }
+                            if (b.type === 'x-oli-organization') {
+                              return 1;
+                            }
+                            if (a.type === 'x-oli-workbook_page') {
+                              return -1;
+                            }
+                            if (b.type === 'x-oli-workbook_page') {
+                              return 1;
+                            }
+                            return 0;
+                          })
+                          .map(res => (
+                            <div key={res.guid} className="ref-thing">
+                              <a href="#" onClick={(event) => {
+                                event.preventDefault();
+                                // if link is to org, just switch org and stay on current page
+                                if (res.type === 'x-oli-organization') {
+                                  viewDocument(resource.id, course.idvers,
+                                    Maybe.maybe(res.id));
+                                } else {
+                                  viewDocument(res.id, course.idvers, Maybe.nothing());
+                                }
+                              }
+                              }>
+                                <span style={{ width: 26, textAlign: 'center', marginRight: 5 }}>
+                                  {
+                                    getNameAndIconByType(res.type).icon}
+                                </span>
+                                {res.title}
+                              </a>
+                            </div>
+                          ))}
                     </div>
                   ) : (
                     <div>No references found</div>

--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -35,6 +35,7 @@ import { RouterState } from 'reducers/router';
 import { Node } from 'data/content/assessment/node';
 import { SidebarToggle } from 'editors/common/SidebarToggle.controller';
 import { CourseState } from 'reducers/course';
+import { AssessmentModel } from 'data/models/assessment';
 
 export interface AssessmentEditorProps extends AbstractEditorProps<models.AssessmentModel> {
   onFetchSkills: (courseId: CourseIdVers) => void;
@@ -86,6 +87,8 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
     nextProps: AssessmentEditorProps,
     nextState: AssessmentEditorState): boolean {
 
+
+
     const shouldUpdate = this.props.model !== nextProps.model
       || this.props.activeContext !== nextProps.activeContext
       || this.props.expanded !== nextProps.expanded
@@ -97,7 +100,7 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
       || this.state.undoStackSize !== nextState.undoStackSize
       || this.state.redoStackSize !== nextState.redoStackSize
       || this.state.collapseInsertPopup !== nextState.collapseInsertPopup;
-
+    console.log('should update', shouldUpdate)
     return shouldUpdate;
   }
 
@@ -566,6 +569,8 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
 
     const page = this.getCurrentPage(this.props);
 
+    console.log('current node', currentNode)
+
     // We currently do not allow expanding / collapsing in the outline,
     // so we simply tell the outline to expand every node.
     const expanded = Immutable.Set<string>(page.nodes.toArray().map(n => n.guid));
@@ -626,7 +631,11 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
             services={services}
             editMode={editMode}
             model={model}
-            onEditModel={onEdit} />
+            onEditModel={(model: AssessmentModel) => {
+              console.log('editing model', model.branching);
+              console.log('model.pages', model.pages)
+              onEdit(model);
+            }} />
         </div>
       </div>);
   }


### PR DESCRIPTION
**Problem**:
When toggling a formative assessment into a branching assessment, the question nodes are sometimes combined. This is the correct behavior, but the UI doesn't update the questions to show the combination, so it looks like your questions have been deleted until you refresh the page. This was seen many times in summer learn lab by Kim and other authors. 

**Solution**:
Update the "active page" of the assessment with the new branching assessment model when toggling to a branching assessment.

**Wireframe / Screenshot if UI work**:
None.

**Risk**:
Very low

**Areas of concern**:
Kim has said a few times that she's been seeing data loss when converting to branching assessments. I suspect that this was the underlying issue, but I need to confirm with her and figure out what she's doing to trigger it. If there is a real data loss concern I'll need to create another PR to fix it, but we should have this fix in place regardless.