### PR TITLE
Fix data loss on branching assessment toggle

### DIFF
--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -377,10 +377,9 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
 
     page = page.with({ nodes: page.nodes.set(node.guid, node) });
 
-    onSetCurrentNodeOrPage(activeContext.documentId.valueOr(null), node);
     this.handleEdit(model.with({
       pages: model.pages.set(page.guid, page),
-    }));
+    }), () => onSetCurrentNodeOrPage(activeContext.documentId.valueOr(null), node));
   }
 
   onRemove() {


### PR DESCRIPTION
**Problem**:
If you add questions in succession after converting to a branching assessment and don't refresh the page, the content you add to the new questions won't save.

To reproduce:
1) Create new formative assessment
2) Convert to branching
3) Add two more questions
4) Add content to the active (third) question
5) Open the first question
6) Go back to the last question and notice that the content is missing

**Solution**:
Very simple once I figured it out - when you add a question node, it updates the assessment model with a new page and sets the active page in redux. The redux action was dispatching before the assessment model had been updated with the new page, so any changes to newly added questions weren't being saved to the page.

I moved the redux action into the `onEdit` callback to trigger after the edit finishes.

**Wireframe / Screenshot if UI work:**
None.

**Risk**:
Low. Isolated change.

**Areas of concern**:
None.