### PR TITLE
Fix multiple choice correct answer selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/reducers/documents.ts
+++ b/src/reducers/documents.ts
@@ -173,16 +173,15 @@ export const documents = (
       }
 
       // Else we are setting the node, so also set the corresponding page
+      const currentPage = assessment.modelType === 'AssessmentModel'
+        ? assessment.pages.reduce(
+          (activePage, page: contentTypes.Page) =>
+            page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
+          ed.currentPage)
+        : Maybe.nothing<string>();
+      const currentNode = Maybe.just(action.nodeOrPageId);
       const node = action.nodeOrPageId;
-      return state.set(action.documentId, ed.with({
-        currentNode: Maybe.just(action.nodeOrPageId),
-        currentPage: assessment.modelType === 'AssessmentModel'
-          ? assessment.pages.reduce(
-            (activePage, page: contentTypes.Page) =>
-              page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
-            ed.currentPage)
-          : Maybe.nothing(),
-      }));
+      return state.set(action.documentId, ed.with({ currentNode, currentPage }));
     default:
       return state;
   }


### PR DESCRIPTION
**Problem**:
Regression bug - multiple choice correct answers could not be changed. a TSMonad stack overflow triggered whenever setting a different answer as correct.

**Solution**:
Something with our TSMonad library is causing issues with our app. I don't fully understand the problem, but through trial and error I was able to refactor the `setCurrentNodeOrPage` reducer to fix the issue.

**Wireframe/Screenshot**:
None.

**Risk**:
Very low, no logic changes, just code structure.

**Areas of concern**:
None, aside from the fact that I don't understand the root cause.
