### PR TITLE
Fix courses view styling

### DIFF
--- a/src/components/CoursesViewSearchable.scss
+++ b/src/components/CoursesViewSearchable.scss
@@ -1,11 +1,14 @@
-@import 'oli/typography';
-
+@import "oli/typography";
 
 .courses-view {
-  flex: 1;
-  overflow: auto;
+    flex: 1;
+    overflow: auto;
 
-  .my-course-packages {
-    margin: 2rem;
-  }
+    .my-course-packages {
+        margin: 2rem;
+    }
+
+    .table-toolbar {
+        flex-direction: row;
+    }
 }


### PR DESCRIPTION
Something messed up the styling of the buttons on the CoursesViewSearchable page.

Before:
![image](https://user-images.githubusercontent.com/16868015/66833585-187cae80-ef2a-11e9-820e-4710e687afc4.png)
After:
![image](https://user-images.githubusercontent.com/16868015/66833628-2a5e5180-ef2a-11e9-8f68-58a31806990e.png)
