### PR TITLE
0.36.0 - Change toolbar button tooltip delay

### DIFF
--- a/src/components/toolbar/ToolbarButton.tsx
+++ b/src/components/toolbar/ToolbarButton.tsx
@@ -55,8 +55,15 @@ class ToolbarButton
 
     return tooltip ?
       (
-        <Tooltip title={tooltip} delay={1000} distance={5} style={{ display: 'inline-block' }}
-          size="small" arrowSize="small">
+        <Tooltip
+          duration={0}
+          title={tooltip}
+          delay={0}
+          distance={5}
+          style={{ display: 'inline-block' }}
+          size="small"
+          arrowSize="small"
+        >
           {button}
         </Tooltip>
       )


### PR DESCRIPTION
I'm proposing that we get rid of the delay on the toolbar button tooltip help text. When we originally set up the resource toolbars, we were worried that if the tooltips showed up immediately on hover it would feel "spammy." But now that we have so many insert and formatting options I feel that that concern is far outweighed by the difficulty of figuring out what each button actually does.

Most other editors (google docs, apple pages, etc.) have an initial delay of about a second before a tooltip shows up, and then any other button you hover over continues to show tooltips after that initial delay was met. In our editor, we don't have a simple way of enabling a "common" delay for all tooltips, so I think the best thing to do is just get rid of the delay on button tooltips so people can more easily figure out where the button they're looking for is.

![image](https://user-images.githubusercontent.com/16868015/66926762-93ae9500-effc-11e9-9a83-7638ab2eca36.png)
