### PR TITLE
0.34.2 - Add skill/LO features for learning engineers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/components/ResourceView.tsx
+++ b/src/components/ResourceView.tsx
@@ -199,6 +199,7 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
   }
 
   renderResources() {
+    const { course, currentOrg } = this.props;
     const rows = this.state.resources.map(r => ({ key: r.guid, data: r }));
 
     const labels = [
@@ -222,23 +223,30 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
     ];
 
     const highlightedColumnRenderer = (prop: string, r: Resource) => {
-      const maybeHighlighted = this.state.searchText.length < 3
+      return this.state.searchText.length < 3
         ? r[prop]
         : highlightMatches(prop, r, this.state.searchText);
-
-      return prop === 'title'
-        ? <span>{getNameAndIconByType(r.type).icon} {maybeHighlighted}</span>
-        : <span>{maybeHighlighted}</span>;
-
     };
 
-    const link = resource => span =>
-      <button onClick={this.onClickResource.bind(this, resource.id)}
-        className="btn btn-link title-btn">{span}</button>;
+    const titleColumnRenderer = (r: Resource) => {
+      const link = resource => element => (
+        <a className="btn-link"
+          href={`/#${course.idvers}/${resource.id}?organization=${currentOrg}`}>
+          {element}
+        </a>
+      );
+      const title = link(r)(highlightedColumnRenderer('title', r));
+      return (
+        <span>{title}</span>
+      );
+    };
+
+    const icon = r => getNameAndIconByType(r.type).icon;
+    const resourceType = r => getNameAndIconByType(r.type).name;
 
     const columnRenderers = [
-      r => link(r)(highlightedColumnRenderer('title', r)),
-      r => <span>{getNameAndIconByType(r.type).name}</span>,
+      r => titleColumnRenderer(r),
+      r => <span>{icon(r)} {resourceType(r)}</span>,
       r => highlightedColumnRenderer('id', r),
       r => <span>{relativeToNow(
         adjustForSkew(r.dateCreated, this.props.serverTimeSkewInMs))}</span>,

--- a/src/components/common/SearchBarLogic.tsx
+++ b/src/components/common/SearchBarLogic.tsx
@@ -7,7 +7,7 @@ import { CourseDescription } from 'components/CoursesViewSearchable';
  *  Raw strings are used to prevent performance issues seen with React.cloneElement
  */
 const cache = {};
-type RowData= Resource | CourseDescription;
+type RowData = Resource | CourseDescription;
 
 export const highlightMatches = (prop: string, r: RowData, searchText): JSX.Element => {
   const textToSearchIn = r[prop];
@@ -18,7 +18,9 @@ export const highlightMatches = (prop: string, r: RowData, searchText): JSX.Elem
 export const highlightMatchesStr = (textToSearchIn: string, searchText): JSX.Element => {
   const lowercasedTextToSearchIn = textToSearchIn.trim().toLowerCase();
   const key = searchText + '|' + lowercasedTextToSearchIn;
-  const divWith = value => <div dangerouslySetInnerHTML={ { __html: value } } />;
+  const divWith = value => <div
+    style={{ display: 'inline-block' }}
+    dangerouslySetInnerHTML={{ __html: value }} />;
 
   if (cache[key]) {
     return divWith(cache[key]);
@@ -27,11 +29,11 @@ export const highlightMatchesStr = (textToSearchIn: string, searchText): JSX.Ele
   const searchTextExpression = new RegExp(searchText, 'i');
   const highlightedText =
     '<span>' +
-      textToSearchIn.replace(searchTextExpression,
-                             '<span class="searchMatch">' +
-                               // Necessary to preserve case of matched text
-                               textToSearchIn.match(searchTextExpression) +
-                             '</span>') +
+    textToSearchIn.replace(searchTextExpression,
+      '<span class="searchMatch">' +
+      // Necessary to preserve case of matched text
+      textToSearchIn.match(searchTextExpression) +
+      '</span>') +
     '</span>';
 
   cache[key] = highlightedText;

--- a/src/components/objectives/InlineEdit.tsx
+++ b/src/components/objectives/InlineEdit.tsx
@@ -2,9 +2,12 @@ import * as React from 'react';
 import { Button } from 'components/common/Button';
 import { classNames } from 'styles/jss';
 import { highlightMatchesStr } from 'components/common/SearchBarLogic.tsx';
+import * as Immutable from 'immutable';
 
 export interface InlineEditProps {
   value: string;
+  // Allows the InlineEdit to "match" values that aren't displayed, like Obj/Skill IDs
+  hiddenValues?: Immutable.List<string>;
   editMode: boolean;
   isEditing: boolean;
   autoFocus?: boolean;
@@ -64,9 +67,9 @@ export class InlineEdit
     }
   }
 
-
-  render() : JSX.Element {
-    const { inputStyle, isEditing, value, editMode, highlightText } = this.props;
+  render(): JSX.Element {
+    const { inputStyle, isEditing, value, editMode, highlightText, hiddenValues }
+      = this.props;
 
     if (isEditing) {
       return (
@@ -81,7 +84,7 @@ export class InlineEdit
             onKeyUp={this.onKeyUp}
             onChange={this.onTextChange}
             onClick={e => e.stopPropagation()}
-            value={this.state.value}/>
+            value={this.state.value} />
           <Button
             className={classNames(['btn btn-sm'])}
             editMode={editMode}
@@ -100,9 +103,24 @@ export class InlineEdit
       );
     }
 
+    const displayValue = <span>
+      {highlightText ? highlightMatchesStr(value, highlightText) : value}
+    </span>;
+
+    const hiddenValueMatch = (displayText: string) => highlightText &&
+      highlightText.length > 2 &&
+      hiddenValues.some(s => s.trim().toLowerCase().includes(highlightText))
+      && (
+        <span style={{ margin: '0 5px', padding: '0 5px' }} className="searchMatch">
+          {displayText}
+        </span>
+      );
+
+    const idMatch = hiddenValueMatch('ID Match');
+
     return (
       <React.Fragment>
-        {highlightText ? highlightMatchesStr(value, highlightText) : value}
+        {displayValue} {idMatch}
       </React.Fragment>
     );
   }

--- a/src/components/objectives/ObjectiveSkillView.scss
+++ b/src/components/objectives/ObjectiveSkillView.scss
@@ -1,74 +1,73 @@
-@import 'oli/colors';
-@import 'oli/layout';
+@import "oli/colors";
+@import "oli/layout";
 
 .objective-skill-view {
-  flex: 1;
-  overflow: auto;
+    flex: 1;
+    overflow: auto;
 
-  td {
-    border-top: 0;
-    padding: .3rem 0;
-  }
-
-  .document {
-    padding-top: 30px;
-  }
-
-  .table-toolbar {
-    display: flex;
-    flex-direction: row;
-    justify-items: center;
-    margin: 20px 0 10px 0;
-  }
-
-  .filter-bar {
-    .selected-org-info {
-      font-size: 0.9rem;
-      color: $gray-darker;
+    td {
+        border-top: 0;
+        padding: .3rem 0;
     }
-  }
 
-  .rst__node .rst__nodeContent h2 {
-    color: $blue;
-    margin-top: 10px;
-  }
+    .document {
+        padding: 30px;
+    }
 
-  .objectives-list {
-    margin-top: 10px;
-    margin-bottom: 30px;
-    background: #fff;
-    padding: 0px 20px;
-    border: 1px solid #ddd;
-    border-radius: 2px;
-  }
+    .table-toolbar {
+        display: flex;
+        flex-direction: row;
+        justify-items: center;
+        margin: 20px 0 10px 0;
+    }
 
-  .page-loading {
-    text-align: center;
-    margin-top: 50px;
-    font-size: 1.3em;
-  }
+    .filter-bar {
+        .selected-org-info {
+            font-size: 0.9rem;
+            color: $gray-darker;
+        }
+    }
 
+    .rst__node .rst__nodeContent h2 {
+        color: $blue;
+        margin-top: 10px;
+    }
+
+    .objectives-list {
+        margin-top: 10px;
+        margin-bottom: 30px;
+        background: #fff;
+        padding: 0px 20px;
+        border: 1px solid #ddd;
+        border-radius: 2px;
+    }
+
+    .page-loading {
+        text-align: center;
+        margin-top: 50px;
+        font-size: 1.3em;
+    }
 }
 
 .ConfirmModal {
-  &.confirm-delete-modal {
-    .btn.btn-primary.confirmBtn {
-      background-color: $remove;
-      border-color: $remove;
+    &.confirm-delete-modal {
+        .btn.btn-primary.confirmBtn {
+            background-color: $remove;
+            border-color: $remove;
 
-      &:hover {
-        background-color: darken($remove, 10%);
-        border-color: darken($remove, 10%);
-      }
+            &:hover {
+                background-color: darken($remove, 10%);
+                border-color: darken($remove, 10%);
+            }
 
-      &:active {
-        background-color: darken($remove, 15%);
-        border-color: darken($remove, 15%);
-      }
+            &:active {
+                background-color: darken($remove, 15%);
+                border-color: darken($remove, 15%);
+            }
 
-      &:focus {
-        outline: none;
-      }
+            &:focus {
+                outline: none;
+            }
+        }
     }
-  }
 }

--- a/src/components/objectives/Skill.tsx
+++ b/src/components/objectives/Skill.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import { StyledComponentProps } from 'types/component';
 import { withStyles, classNames, JSSStyles } from 'styles/jss';
 import colors from 'styles/colors';
@@ -12,9 +12,7 @@ import { Tooltip } from 'utils/tooltip';
 import { calculateGuaranteedSummativeCount } from 'components/objectives/utils';
 import { QuestionRef } from 'types/questionRef';
 import { LegacyTypes } from 'data/types';
-import {
-  checkModel, ModelCheckerRule, RequirementType,
-} from 'data/linter/modelChecker';
+import { checkModel, ModelCheckerRule, RequirementType } from 'data/linter/modelChecker';
 
 export interface ModelRuleData {
   formativeCount: number;
@@ -110,6 +108,7 @@ export interface SkillProps {
   onEnterEditMode: () => void;
   onExitEditMode: () => void;
   onRemoveSkill: (skill: contentTypes.Skill) => void;
+  showId?: boolean;
 }
 
 export interface SkillState {
@@ -243,8 +242,12 @@ class Skill
   render() {
     const {
       className, classes, skill, editMode, loading, highlightText, isEditing, onEditSkill,
-      onExitEditMode,
+      onExitEditMode, showId,
     } = this.props;
+
+    const displayValue = showId
+      ? skill.title + ` (${skill.id})`
+      : skill.title;
 
     return (
       <div className={classNames(['Skill', classes.Skill, className])}>
@@ -260,7 +263,9 @@ class Skill
             }}
             onCancel={() => onExitEditMode()}
             editMode={editMode && !loading}
-            value={skill.title} />
+            value={displayValue}
+            hiddenValues={showId ? List([]) : List([skill.id])}
+          />
         </div>
         {!isEditing &&
           <div className={classes.skillActions}>


### PR DESCRIPTION
**Problem**:
Learning engineers have no easy way to match skill IDs downloaded from the editor (on the Course Overview page and from the Data Analytics page) to actual skills and the questions they're attached to. 

**Solution**:
1) Add searching by ID on the learning objective/skill page
2) Add ability to display IDs on learning objective/skill page
3) Make links to questions on learning objective/skill page openable in new tab
4) Make "all resources" table copyable and able to open links to resources in new tab

**Wireframe/Screenshot**:
![image](https://user-images.githubusercontent.com/16868015/66786908-02320c80-eeb0-11e9-9f82-719a64c7ca8b.png)
![image](https://user-images.githubusercontent.com/16868015/66786958-1aa22700-eeb0-11e9-884d-8e7d0cbc151a.png)
![image](https://user-images.githubusercontent.com/16868015/66786933-09f1b100-eeb0-11e9-949b-b2126f927505.png)
![image](https://user-images.githubusercontent.com/16868015/66786946-1249ec00-eeb0-11e9-9d54-efec32bb2537.png)

**Risk**:
Low, mostly affects display.

**Areas of concern**:
None.