### PR TITLE
0.37.0 - Fix inserting items when selecting content decorator

### DIFF
--- a/src/editors/content/container/ContentContainer.tsx
+++ b/src/editors/content/container/ContentContainer.tsx
@@ -9,7 +9,6 @@ import { ContentDecorator } from 'editors/content/container/ContentDecorator';
 import { ContiguousText } from 'data/content/learning/contiguous';
 import { ContentElement } from 'data/content/common/interfaces';
 import { Maybe } from 'tsmonad';
-import { TextSelection } from 'types/active';
 import guid from 'utils/guid';
 import './ContentContainer.scss';
 import { classNames } from 'styles/jss';
@@ -133,8 +132,10 @@ export class ContentContainer
             const updated: ContentElements = this.insertAfter(model, arrToAdd, index);
             onEdit(updated.with({ content: updated.content.delete(activeContentGuid) }), firstItem);
 
-            // We insert after when the cursor is at the end
-          } else if (editorUtils.isCursorAtEffectiveEnd(e)) {
+
+            // We insert after when the cursor is at the end or
+            // the content decorator is selected
+          } else if (!editorUtils.isCursorInText(e) || editorUtils.isCursorAtEffectiveEnd(e)) {
             onEdit(this.insertAfter(model, arrToAdd, index), firstItem);
 
             // If it is at the beginning, insert the new item before the text

--- a/src/editors/content/learning/contiguoustext/utils.tsx
+++ b/src/editors/content/learning/contiguoustext/utils.tsx
@@ -7,6 +7,10 @@ import guid from 'utils/guid';
 
 export type ValuePair = [Value, Value];
 
+export function isCursorInText(editor: Editor): boolean {
+  return editor.value.selection.isFocused;
+}
+
 // Helper routine to turn the current selection into an inline
 function wrapInlineWithData(editor, wrapper) {
   editor.wrapInline({


### PR DESCRIPTION
**Problem**:
Inserting content into a workbook page can fail when a content decorator is selected because the insert logic does not take into account the case when no text is selected. The logic falls through to the base case which splits text rather than inserting the item after the selected decorator.

**Solution**:
Support the case when a content decorator is selected by checking if there is a "focused" text selection.

**Wireframe/Screenshot**:
None.

**Risk**:
Low.

**Areas of concern**:
None.