### PR TITLE
0.37.0 - Fix Firefox Dropdown Input Selection

### DIFF
--- a/src/editors/content/learning/contiguoustext/render/InputRefDisplay.tsx
+++ b/src/editors/content/learning/contiguoustext/render/InputRefDisplay.tsx
@@ -46,8 +46,10 @@ class InputRefDisplay extends React.PureComponent<InputRefProps, InputRefState> 
         onClick={handleClick} readOnly value="Text" size={15} />;
     }
     if (inputType === InputRefType.FillInTheBlank) {
-      return <select {...attrs} className={active}
-        onClick={handleClick} style={{ width: '100px' }} />;
+      return <input {...attrs} className={active}
+        onClick={handleClick} readonly
+        style={{ width: '100px', border: '1px', textAlign: 'center' }}
+        placeholder="Dropdown" />;
     }
     return <input {...attrs} className={active}
       onClick={handleClick} readOnly value="Text" size={15} />;


### PR DESCRIPTION
**Problem**:
Dropdown input elements cannot be selected in Firefox after being inserted into a question. The issue was that Firefox does not support the `onClick` handler in `<select>` elements, so the selection was never getting triggered. 

**Solution**:
Change the `<select>` element to an `<input>`. The look and feel is a little different - I added a placeholder text to signal that it's a dropdown and not a normal input, but I'm open to suggestions if we want to present it in a different way.

**Wireframe/Screenshot**:
None.

**Risk**:
Low.

**Areas of concern**:
None.