### PR TITLE
0.37.0 - Prevent text insertion when selecting text

### DIFF
--- a/src/components/toolbar/InsertToolbar.tsx
+++ b/src/components/toolbar/InsertToolbar.tsx
@@ -129,7 +129,13 @@ class InsertToolbar
   render() {
     const { onInsert, parentSupportsElementType, resourcePath, context, editMode,
       courseModel, onDisplayModal, onDismissModal, requestLatestModel,
-      onCreateNew } = this.props;
+      onCreateNew, activeContext } = this.props;
+
+    const isParagraphSelected = activeContext.activeChild.caseOf({
+      just: c => c instanceof ContiguousText,
+      nothing: () => false,
+    });
+
     const onTableCreate = (onInsert, numRows, numCols) => {
 
       const rows = [];
@@ -254,7 +260,7 @@ class InsertToolbar
             <ToolbarButton
               size={ToolbarButtonSize.Wide}
               onClick={() => onInsert(contentTypes.ContiguousText.fromText('', guid()))}
-              disabled={!editMode || !parentSupportsElementType('p')}>
+              disabled={!editMode || !parentSupportsElementType('p') || isParagraphSelected}>
               {getContentIcon(insertableContentTypes.ContiguousText)} Text
               </ToolbarButton>
             <ToolbarWideMenu


### PR DESCRIPTION
**Problem**:
This PR was part of a larger investigation to ensure our text insertion and splitting logic was correct, and the main issue is fixed as part of `AUTHORING-2148`. This PR has a separate smaller piece, which is to prevent `ContiguousText` insertion when a paragraph element is currently selected.

**Solution**:
Check if the actively selected item is a paragraph and prevent inserting another text block if so.

**Wireframe/Screenshot**:
None.

**Risk**:
Low.

**Areas of concern**:
None.