### PR TITLE
0.37.0 - Fix thrown error on objectives page

### DIFF
--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -248,7 +248,7 @@ function subElementInline(
 function inputRef(item: Object, parent: BlockJSON, backingTextProvider): InlineJSON {
 
   const value = (InputRef.fromPersistence as any)(item);
-  const inputTypeStr = backingTextProvider[value.input].contentType;
+  const inputTypeStr = backingTextProvider && backingTextProvider[value.input].contentType;
   let inputType = InputRefType.Numeric;
   if (inputTypeStr === 'Text') {
     inputType = InputRefType.Text;

--- a/src/editors/document/analytics/Analytics.tsx
+++ b/src/editors/document/analytics/Analytics.tsx
@@ -361,19 +361,13 @@ class Analytics
             + `&partId=${part.id}`)}>
           Part {part.index + 1}
         </div>
-        {analytics.dataSet.caseOf({
-          just: analyticsDataSet => analyticsDataSet.byResourcePart.caseOf({
-            just: byResourcePart => Maybe.maybe(
-              analyticsDataSet.status === DatasetStatus.DONE
-              && byResourcePart.getIn([question.assessmentId, part.id]),
-            ).caseOf({
-              just: partAnalytics => <PartAnalytics partAnalytics={partAnalytics} />,
-              nothing: () => this.renderNoAnalyticsMsg(),
-            }),
+        {analytics.dataSet.bind(analyticsDataSet => analyticsDataSet.byResourcePart
+          .lift(byResourcePart => analyticsDataSet.status === DatasetStatus.DONE
+            && byResourcePart.getIn([question.assessmentId, part.id])))
+          .caseOf({
+            just: partAnalytics => <PartAnalytics partAnalytics={partAnalytics} />,
             nothing: () => this.renderNoAnalyticsMsg(),
-          }),
-          nothing: () => this.renderNoAnalyticsMsg(),
-        })}
+          })}
       </div>
     ));
   }
@@ -393,22 +387,14 @@ class Analytics
             {question.title.valueOr(getReadableTitleFromType(question.type))}
           </div>
           {parts.size === 1 && (
-            Maybe.maybe(parts.first()).caseOf({
-              just: part => analytics.dataSet.caseOf({
-                just: analyticsDataSet => analyticsDataSet.byResourcePart.caseOf({
-                  just: byResourcePart => Maybe.maybe(
-                    byResourcePart.getIn([question.assessmentId, part.id]),
-                  ).caseOf({
-                    just: partAnalytics => <PartAnalytics partAnalytics={partAnalytics} />,
-                    nothing: () => this.renderNoAnalyticsMsg(),
-                  }),
-                  nothing: () => this.renderNoAnalyticsMsg(),
-                }),
+            Maybe.maybe(parts.first())
+              .bind(part => analytics.dataSet
+                .bind(analyticsDataset => analyticsDataset.byResourcePart
+                  .lift(byResourcePart => byResourcePart.getIn([question.assessmentId, part.id]))))
+              .caseOf({
+                just: partAnalytics => <PartAnalytics partAnalytics={partAnalytics} />,
                 nothing: () => this.renderNoAnalyticsMsg(),
-              }),
-              nothing: () => this.renderNoAnalyticsMsg(),
-            })
-          )}
+              }))}
         </div>
         {parts.size > 1 && this.renderMultipleParts(question, skill, organization)}
       </div>


### PR DESCRIPTION
**Problem**:
Expanding analytics data for objectives that reference an input question throws an error.

**Solution**:
When the slate model is parsed, it assumes `backingTextProvider` is defined, so it throws an error when null. That variable is used to select the input question type, which doesn't matter on the Analytics page since we're just getting the question stem text. So it's fine to just default to a numeric question and continue getting the text.

**Wireframe/Screenshot**:
None.

**Risk**:
Low. I also refactored some of the `Analytics` logic when testing since I couldn't tell if it was working properly.

**Areas of concern**:
None.