### PR TITLE
0.37.0 - Fix selecting the correct node when toggling branching assessment

### DIFF
--- a/src/reducers/documents.ts
+++ b/src/reducers/documents.ts
@@ -173,14 +173,14 @@ export const documents = (
       }
 
       // Else we are setting the node, so also set the corresponding page
+      const node = action.nodeOrPageId;
       const currentPage = assessment.modelType === 'AssessmentModel'
         ? assessment.pages.reduce(
           (activePage, page: contentTypes.Page) =>
             page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
           ed.currentPage)
         : Maybe.nothing<string>();
-      const currentNode = Maybe.just(action.nodeOrPageId);
-      const node = action.nodeOrPageId;
+      const currentNode = Maybe.just(node);
       return state.set(action.documentId, ed.with({ currentNode, currentPage }));
     default:
       return state;


### PR DESCRIPTION
**Problem**:
Regression - toggling a branching assessment without a page refresh causes data loss when continuing to edit questions.

Steps to reproduce:
1. In echo, create a new formative assessment.
2. Flip the switch to make it a branching assessment.
3. Add a second and third multiple choice question and try to add text to the prompts/answers.
4. Wait for "All changes saved" in the top-right.
5. Leave the question and come back to it. The text will be gone 

**Solution**:
The `setCurrentNodeOrPage` reducer function was incorrect and didn't find the right node when adding questions that result in new pages being created, which is the case for branching assessments.

**Wireframe/Screenshot**:
None.

**Risk**:
Low.

**Areas of concern**:
None.