### PR TITLE
0.37.0 - Fix toolbar insertion issue when selecting text

### DIFF
--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
@@ -75,6 +75,10 @@ class ContiguousTextEditor
         this.props.onUpdateEditor(this.editor);
         this.editor.focus();
 
+        // Do not broadcast changes if the editor is unfocused (de-selected)
+      } else if (updateSelection && !v.selection.isFocused) {
+        return;
+
       } else if (updateSelection) {
 
         // Broadcast the fact that the editor updated

--- a/src/editors/content/learning/contiguoustext/utils.tsx
+++ b/src/editors/content/learning/contiguoustext/utils.tsx
@@ -50,9 +50,10 @@ export function isEffectivelyEmpty(editor: Editor): boolean {
 // positioned in the last block and no text other than spaces
 // follows the cursor
 export function isCursorAtEffectiveEnd(editor: Editor): boolean {
-  const node = (editor.value.document.nodes
+  const block = (editor.value.document.nodes
     .get(editor.value.document.nodes.size - 1) as Block);
-  const { key, text } = node;
+  const { nodes, text } = block;
+  const key = nodes.get(0).key;
 
   const selection = editor.value.selection;
 
@@ -64,7 +65,8 @@ export function isCursorAtEffectiveEnd(editor: Editor): boolean {
 // Returns true if the selection is collapsed and is at the
 // very beginning of the first block
 export function isCursorAtBeginning(editor: Editor): boolean {
-  const key = (editor.value.document.nodes.get(0) as Block).key;
+  const block = (editor.value.document.nodes.get(0) as Block);
+  const key = block.nodes.get(0).key;
   const selection = editor.value.selection;
   return selection.isCollapsed
     && key === selection.anchor.key


### PR DESCRIPTION
**Problem**:
The editor could get into weird states from inserting items from the toolbar when contiguous text or content decorators were selected.

Cases not handled correctly:
1. Cursor at beginning of contiguous text
2. Cursor at end of contiguous text
3. Only content decorator selected, no text focus
4. Cursor inside contiguous text, then selecting another contiguous text block's content decorator

**Solution**:
1. Update slate utils to identify when cursor is at beginning or end of contiguous text block
2. Reset the active editor when a content decorator is selected
3. Stop broadcasting slate changes when an editor instance is de-selected (by checking `isFocused`)

**Wireframe/Screenshot**:
None.

**Risk**:
Medium - core text editing logic.

**Areas of concern**:
None.