### PR TITLE
Fix language attribute usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -151,7 +151,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
         : contentTypes.MetaData.fromPersistence(c.metadata.jsonObject);
 
     const language =
-      isNullOrUndefined(c.misc.jsonObject)
+      isNullOrUndefined(c.misc) || isNullOrUndefined(c.misc.jsonObject)
         ? 'en_US'
         : c.misc.jsonObject['language'];
 

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -152,7 +152,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
 
     const language =
       isNullOrUndefined(c.misc.jsonObject)
-        ? ''
+        ? 'en_US'
         : c.misc.jsonObject['language'];
 
     const resources =

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -5,7 +5,6 @@ import { LegacyTypes } from '../types';
 import { parseDate } from 'utils/date';
 import { DatasetStatus } from 'types/analytics/dataset';
 import { CourseIdVers, CourseGuid } from 'data/types';
-import { Maybe } from 'tsmonad';
 import { localeCodes } from 'data/content/learning/foreign';
 
 // Must match DeployStage enum values in ContentService
@@ -74,7 +73,7 @@ const defaultCourseModel = {
   icon: new contentTypes.WebContent(),
   theme: '',
   activeDataset: null,
-  language: localeCodes['Spanish (LATAM)'],
+  language: localeCodes['English (USA)'],
   resources: Immutable.OrderedMap<string, contentTypes.Resource>(),
   resourcesById: Immutable.OrderedMap<string, contentTypes.Resource>(),
   webContents: Immutable.OrderedMap<string, contentTypes.WebContent>(),
@@ -128,7 +127,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
     dateCreated: string;
     guid: string;
   };
-  language: '';
+  language: string;
   resources: Immutable.OrderedMap<string, contentTypes.Resource>;
   resourcesById: Immutable.OrderedMap<string, contentTypes.Resource>;
   webContents: Immutable.OrderedMap<string, contentTypes.WebContent>;
@@ -150,6 +149,11 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
       isNullOrUndefined(c.metadata.jsonObject)
         ? new contentTypes.MetaData()
         : contentTypes.MetaData.fromPersistence(c.metadata.jsonObject);
+
+    const language =
+      isNullOrUndefined(c.misc.jsonObject)
+        ? ''
+        : c.misc.jsonObject['language'];
 
     const resources =
       isNullOrUndefined(c.resources)
@@ -191,7 +195,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
       icon: new contentTypes.WebContent(),
       theme: c.theme,
       activeDataset: c.activeDataset,
-      language: c.language || localeCodes['Spanish (LATAM)'],
+      language,
       metadata,
       resources,
       webContents,
@@ -212,7 +216,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
         metadata: this.metadata.toPersistence(),
         description: this.description,
         preferences: this.options,
-        language: this.language || localeCodes['Spanish (LATAM)'],
+        misc: { language: this.language || 'en_US' },
       },
     }];
     const values = {

--- a/src/editors/content/container/ToolbarContentContainer.tsx
+++ b/src/editors/content/container/ToolbarContentContainer.tsx
@@ -146,7 +146,9 @@ class ToolbarContentContainer
               () => this.props.editor.lift((e) => {
                 e.toggleMark({
                   type: InlineStyles.Foreign,
-                  data: Data.create({ lang: course.language || localeCodes['Spanish (LATAM)'] }),
+                  data: Data.create({
+                    lang: course.language || localeCodes['English (USA)'],
+                  }),
                 });
               })
             }

--- a/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.tsx
@@ -369,8 +369,7 @@ class ContiguousTextToolbar
                 e.toggleMark({
                   type: InlineStyles.Foreign,
                   data: Data.create({
-                    lang: courseModel.language ||
-                      localeCodes['Spanish (LATAM)'],
+                    lang: courseModel.language || localeCodes['English (USA)'],
                   }),
                 });
               })

--- a/src/editors/document/course/CourseEditor.tsx
+++ b/src/editors/document/course/CourseEditor.tsx
@@ -368,7 +368,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
     const savedLocale = Object.entries(localeCodes).find(
       ([_, code]) => code as string === this.props.model.language);
 
-    const defaultValue = savedLocale ? savedLocale[0] : localeCodes['Spanish (LATAM)'];
+    const defaultValue = savedLocale ? savedLocale[0] : 'English (USA)';
 
     return (
       <div className="row">
@@ -405,7 +405,7 @@ class CourseEditor extends React.Component<CourseEditorProps, CourseEditorState>
     const model = this.props.model.with({
       language: localeFriendly in localeCodes
         ? localeCodes[localeFriendly]
-        : localeCodes['Spanish (LATAM)'],
+        : localeCodes['English (USA)'],
     });
     this.props.courseChanged(model);
     const doc = new Document().with({


### PR DESCRIPTION
server branch: same name, `language-hotfix`

Deploying courses causes a build error.

The main change is to go from saving the default/chosen foreign language from the language element on the content_package table and XML to a new misc JSON field in the database. The client had to be changed to use this new field.