### PR TITLE
0.38.0 - Enable numeric input questions to have multiple correct answers

### DIFF
--- a/src/data/content/assessment/question.ts
+++ b/src/data/content/assessment/question.ts
@@ -590,7 +590,7 @@ depending on their answer. Each response has a `match` attribute which tells OLI
 answer should receive that response. Now, some question types allow a "catchall" response to match
 any answer choice that is not specifically listed by the course author. These catchall responses
 have the `match` attribute set to the "*" string. OLI processes question responses in-order,
-meaning that if a catchall response comes before a targeted response in the DTO json, it will
+meaning that if a catchall response comes before a targeted response in the json DTO, it will
 ignore all of the following targeted responses. The problem was that Echo sometimes puts the
 catchall response in the middle of the targeted feedback, and so we ran into bugs where, for
 example, numeric input questions could not have two correct answers because the catchall response

--- a/src/data/content/assessment/question.ts
+++ b/src/data/content/assessment/question.ts
@@ -604,9 +604,9 @@ function putMatchStarResponseAtEnd(question: Question): Question {
     return responses.filter(response => !isStarMatch(response.match));
   }
 
-  function responsesWithStarMatches(
+  function responseWithStarMatch(
     responses: Immutable.OrderedMap<string, ct.Response>): Immutable.Iterable<string, ct.Response> {
-    return responses.filter(response => isStarMatch(response.match));
+    return responses.filter(response => isStarMatch(response.match)).first();
   }
 
   // Logic
@@ -618,7 +618,7 @@ function putMatchStarResponseAtEnd(question: Question): Question {
     parts: question.parts.map(part =>
       part.with({
         responses: responsesWithoutStarMatches(part.responses)
-          .concat(responsesWithStarMatches(part.responses))
+          .concat(responseWithStarMatch(part.responses))
           .toOrderedMap(),
       })).toOrderedMap(),
   });

--- a/src/data/content/assessment/question.ts
+++ b/src/data/content/assessment/question.ts
@@ -606,7 +606,11 @@ function putMatchStarResponseAtEnd(question: Question): Question {
 
   function responseWithStarMatch(
     responses: Immutable.OrderedMap<string, ct.Response>): Immutable.Iterable<string, ct.Response> {
-    return responses.filter(response => isStarMatch(response.match)).first();
+    const matches = responses.filter(response => isStarMatch(response.match));
+    if (matches && matches.size > 0) {
+      return matches.first();
+    }
+    return matches;
   }
 
   // Logic

--- a/src/data/content/assessment/question.ts
+++ b/src/data/content/assessment/question.ts
@@ -584,6 +584,7 @@ export function catchallResponseOrderingIsValid(question: Question): boolean {
 }
 
 /*
+See AUTHORING-2170.
 Each question part has a list of responses with scores and feedback that are given to students
 depending on their answer. Each response has a `match` attribute which tells OLI which
 answer should receive that response. Now, some question types allow a "catchall" response to match

--- a/test/data/content/assessment/input-numeric-test.ts
+++ b/test/data/content/assessment/input-numeric-test.ts
@@ -2,6 +2,8 @@ import { Question } from 'data/content/assessment/question';
 import guid from 'utils/guid';
 import { responsesMatchAnswerChoices, testScores } from './_questions-test';
 const jsonInputNumeric = require('./questions-valid/input-numeric.json');
+const jsonMatchStarValid = require('./questions-valid/input-numeric-match-star.json');
+const jsonMatchStarInvalid = require('./questions-invalid/input-numeric-match-star.json');
 
 // tslint:disable max-line-length
 describe('input - numeric should be parsed correctly', () => {
@@ -43,4 +45,34 @@ describe('input - numeric should be parsed correctly', () => {
   });
 
   testScores(responses);
+});
+
+
+describe('input - numeric have `match: "*" responses only at the end`', () => {
+  // This question has a response with match "*" in the wrong position, and needs a change
+  const invalidQuestionStarMatch: Question = Question.fromPersistence(
+    Question.fromPersistence(jsonMatchStarInvalid, guid()).toPersistence(),
+    guid());
+
+  // This question has the match "*" in the correct position, and needs no change
+  const validQuestionStarMatch: Question = Question.fromPersistence(
+    Question.fromPersistence(jsonMatchStarValid, guid()).toPersistence(),
+    guid());
+
+  it('makes no changes to the responses when a `match: "*"` is at the end', () => {
+    expect(validQuestionStarMatch.toPersistence()).toEqual(jsonMatchStarValid);
+  });
+
+  it('makes a change to the responses when a `match: "*" is not at the end', () => {
+    expect(invalidQuestionStarMatch.toPersistence()).not.toEqual(jsonMatchStarInvalid);
+  });
+
+  it('does not allow responses to have a `match: "*"` except for at the end', () => {
+    expect(invalidQuestionStarMatch.parts.every(part =>
+      part.responses.butLast().every(response => response.match !== '*'))).not.toBe(false);
+  });
+
+  it('ensures the `match: "*"` stays at the end for valid questions', () => {
+    expect(invalidQuestionStarMatch.parts.some(part => part.responses.last().match === '*')).toBe(true);
+  });
 });

--- a/test/data/content/assessment/questions-invalid/input-numeric-match-star.json
+++ b/test/data/content/assessment/questions-invalid/input-numeric-match-star.json
@@ -1,0 +1,157 @@
+{
+  "question": {
+    "@id": "b69defe978c745f8b4416221d05f071c",
+    "@grading": "automatic",
+    "#array": [
+      {
+        "body": {
+          "#array": [
+            {
+              "p": {
+                "#array": [
+                  {
+                    "#text": "Add "
+                  },
+                  {
+                    "input_ref": {
+                      "@input": "d1a2a2b522374a59ac397e59cffd5999"
+                    }
+                  },
+                  {
+                    "#text": ", text, or dropdown components"
+                  }
+                ],
+                "@id": "a870369acb6c413099a328303de1b79d"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "numeric": {
+          "@id": "d1a2a2b522374a59ac397e59cffd5999",
+          "@size": "small",
+          "@notation": "automatic"
+        }
+      },
+      {
+        "part": {
+          "@id": "f648a7e1970843e0b1a884238a42efce",
+          "@targets": "",
+          "#array": [
+            {
+              "title": {
+                "#text": ""
+              }
+            },
+            {
+              "response": {
+                "@match": "0",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Correct!"
+                              }
+                            ],
+                            "@id": "ad53eecf76624e5a9cd0894a3d4a19e1"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "1",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "response": {
+                "@match": "*",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Incorrect."
+                              }
+                            ],
+                            "@id": "c0eab005ab9c4d38bc0ae41f316c37c5"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "0",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "response": {
+                "@match": "1",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Correct!"
+                              }
+                            ],
+                            "@id": "a63fda9f42e2467ca1109ac72e410334"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "1",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "explanation": {
+                "#array": [
+                  {
+                    "p": {
+                      "#array": [],
+                      "@id": "a52a448asdf22fb242928062552b5b93df20"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "explanation": {
+          "#array": [
+            {
+              "p": {
+                "#array": [],
+                "@id": "dffc76b349e54eaa969efd61b71b7b43"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/data/content/assessment/questions-valid/input-numeric-match-star.json
+++ b/test/data/content/assessment/questions-valid/input-numeric-match-star.json
@@ -1,0 +1,157 @@
+{
+  "question": {
+    "@id": "b69defe978c745f8b4416221d05f071c",
+    "@grading": "automatic",
+    "#array": [
+      {
+        "body": {
+          "#array": [
+            {
+              "p": {
+                "#array": [
+                  {
+                    "#text": "Add "
+                  },
+                  {
+                    "input_ref": {
+                      "@input": "d1a2a2b522374a59ac397e59cffd5999"
+                    }
+                  },
+                  {
+                    "#text": ", text, or dropdown components"
+                  }
+                ],
+                "@id": "a870369acb6c413099a328303de1b79d"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "numeric": {
+          "@id": "d1a2a2b522374a59ac397e59cffd5999",
+          "@size": "small",
+          "@notation": "automatic"
+        }
+      },
+      {
+        "part": {
+          "@id": "f648a7e1970843e0b1a884238a42efce",
+          "@targets": "",
+          "#array": [
+            {
+              "title": {
+                "#text": ""
+              }
+            },
+            {
+              "response": {
+                "@match": "0",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Correct!"
+                              }
+                            ],
+                            "@id": "ad53eecf76624e5a9cd0894a3d4a19e1"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "1",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "response": {
+                "@match": "1",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Correct!"
+                              }
+                            ],
+                            "@id": "a63fda9f42e2467ca1109ac72e410334"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "1",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "response": {
+                "@match": "*",
+                "@name": "",
+                "#array": [
+                  {
+                    "feedback": {
+                      "#array": [
+                        {
+                          "p": {
+                            "#array": [
+                              {
+                                "#text": "Incorrect."
+                              }
+                            ],
+                            "@id": "c0eab005ab9c4d38bc0ae41f316c37c5"
+                          }
+                        }
+                      ],
+                      "@targets": ""
+                    }
+                  }
+                ],
+                "@score": "0",
+                "@input": "d1a2a2b522374a59ac397e59cffd5999"
+              }
+            },
+            {
+              "explanation": {
+                "#array": [
+                  {
+                    "p": {
+                      "#array": [],
+                      "@id": "a52a448asdf22fb242928062552b5b93df20"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "explanation": {
+          "#array": [
+            {
+              "p": {
+                "#array": [],
+                "@id": "dffc76b349e54eaa969efd61b71b7b43"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Problem**:

See Jira ticket for more info:
https://olidev.atlassian.net/browse/AUTHORING-2170

OLI supports numeric input question with multiple correct answers, but Echo doesn't. This is necessary for one of the courses that the learning engineers are migrating to Echo.

The problem in the code is that when "catch-all" responses are created for generic incorrect feedback (using the `match: '*'` attribute), they sometimes get inserted into the middle of the `Responses` map on the `Part`. These are persisted in order, and when OLI goes to create the question, it sees the `match: '*'` and disregards any targeted feedback in the responses following it.

_To reproduce:_
1. Create an assessment (formative or summative) with a numeric input question
2. Create two "correct" answers, each with a score of 1 (or something above 0)
3. Preview the assessment and see that the second correct answer is not recognized and no points are given

**Solution**:
The issue could be fixed whenever we created the `Responses` with `match: '*'`, but there are a few different places that do this, and solving it here wouldn't fix any existing numeric input questions with this problem. So I decided to correct the `match: '*'` response ordering in the question persistence.

The solution was to check if a response had any catch-all feedback using the `match: '*'`, and if it did, find out if the response was nested in the middle of other responses. If so, move that response to the end so that targeted feedback takes priority.

**Wireframe/Screenshot**:
None.

**Risk**:
Very high - affects persistence logic for all questions.

**Areas of concern**:
1. Added unit tests to catch this case
2. Tested both formative and summative assessments
3. Tested with raw XML