### PR TITLE
0.38.0 - Fix organization component analytics refresh issue

### DIFF
--- a/src/editors/document/org/OrgComponentEditor.tsx
+++ b/src/editors/document/org/OrgComponentEditor.tsx
@@ -89,7 +89,6 @@ export class OrgComponentEditor
     }
     if (this.props.componentId !== nextProps.componentId
       || isDifferentOrg(this.props.org, nextProps.org)) {
-      console.log('Finding component model')
       this.findComponentModel(nextProps);
     }
   }

--- a/src/editors/document/org/OrgComponentEditor.tsx
+++ b/src/editors/document/org/OrgComponentEditor.tsx
@@ -83,8 +83,13 @@ export class OrgComponentEditor
   }
 
   componentWillReceiveProps(nextProps: OrgComponentEditorProps) {
+    function isDifferentOrg(thisOrg, nextOrg) {
+      const thisOrgId = thisOrg.valueOr({ resource: {} }).resource.id;
+      return !thisOrgId || thisOrgId !== nextOrg.valueOr({ resource: {} }).resource.id;
+    }
     if (this.props.componentId !== nextProps.componentId
-      || this.props.org !== nextProps.org) {
+      || isDifferentOrg(this.props.org, nextProps.org)) {
+      console.log('Finding component model')
       this.findComponentModel(nextProps);
     }
   }


### PR DESCRIPTION
**Problem**:
When viewing analytics for an org component (unit, module, section), the page flickers pretty badly and new requests for new analytics data keep being made.

There are two separate issues here:
1. `componentWillReceiveProps` in `OrgComponentEditor` was using the reference equality operator on two `Maybe`s, so the `findComponentModel` kept running
2. Some higher level component keeps creating a new organization model and passing it down to this component, so looking inside the `Maybe`s to compare the organization model itself wasn't working

**Solution**:
Issue #1 was simple to fix. For issue #2, I spent a fair amount of time tracking down why the organization model kept being re-created and passed down to the `OrgComponentEditor`. I ended up touching a lot of different heavily used components (`Main`, `EditorManager`, `NavigationPanel`) to fix the issue before I realized it was riskier than it was worth. Eventually, I realized we can just check the organization model's resource ID to determine if it's truly a different org or not.

**Wireframe/Screenshot**:
None.

**Risk**:
Low - only applies to viewing an organization component.

**Areas of concern**:
The root issue of passing new organization model wrappers to the component was not fixed.