### PR TITLE
0.38.0 - Add console log for errors that are caught

### DIFF
--- a/src/components/GlobalError.tsx
+++ b/src/components/GlobalError.tsx
@@ -22,6 +22,11 @@ const GlobalError:
     classes, user, error,
   }) => {
 
+    useEffect(() => {
+      // Report this error to the console
+      console.error(error);
+    });
+
     const [reported, setReported] = useState(false);
     useEffect(() => {
       // Report this error event to google analytics


### PR DESCRIPTION
It doesn't seem like the `GlobalError` component was actually displaying the thrown error that caused it to trigger. It is showing subsequent errors (like React's "this error was caused by the x component.")