### PR TITLE
0.38.0 - Fix inlines breaking course build when text content is empty

### DIFF
--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -29,15 +29,15 @@ export function toPersistence(value: Value, inlineText = false): Object {
 
 // Top-level block handler.
 function translateNode(node: Block, seenIds: Object) {
-  const inlineHasContent = (n: Inline) => n.nodes.size > 0 && n.nodes.first().text.trim() !== '';
   const content = [];
 
   // Process each child node
   node.nodes.forEach((n) => {
+    console.log('n', n)
     if (n.object === 'text' && n.text.length > 0) {
       handleText(n, content);
       // Don't save inlines with empty text content inside
-    } else if (n.object === 'inline' && inlineHasContent(n)) {
+    } else if (n.object === 'inline') {
       handleInline(n, content);
     }
   });
@@ -192,6 +192,12 @@ function terminalInline(i: Inline, container) {
 // content inlines serialize the embedded wrapper, but also
 // additional slate objects
 function contentBasedInline(i: Inline, container) {
+  const inlineHasContent = (i: Inline) => i.nodes.size > 0 && i.nodes.first().text.trim() !== '';
+  // Don't persist content-based inlines with no text content
+  if (!inlineHasContent(i)) {
+    return;
+  }
+
   const item = i.data.get('value').toPersistence();
   const key = common.getKey(item);
   container.push(item);

--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -29,7 +29,7 @@ export function toPersistence(value: Value, inlineText = false): Object {
 
 // Top-level block handler.
 function translateNode(node: Block, seenIds: Object) {
-  const isInlineEmpty = (n: Inline) => n.nodes.size > 0 && n.nodes.first().text.trim() === '';
+  const inlineHasContent = (n: Inline) => n.nodes.size > 0 && n.nodes.first().text.trim() !== '';
   const content = [];
 
   // Process each child node
@@ -37,7 +37,7 @@ function translateNode(node: Block, seenIds: Object) {
     if (n.object === 'text' && n.text.length > 0) {
       handleText(n, content);
       // Don't save inlines with empty text content inside
-    } else if (n.object === 'inline' && !isInlineEmpty(n)) {
+    } else if (n.object === 'inline' && inlineHasContent(n)) {
       handleInline(n, content);
     }
   });

--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -29,13 +29,15 @@ export function toPersistence(value: Value, inlineText = false): Object {
 
 // Top-level block handler.
 function translateNode(node: Block, seenIds: Object) {
+  const isInlineEmpty = (n: Inline) => n.nodes.size > 0 && n.nodes.first().text.trim() === '';
   const content = [];
 
   // Process each child node
   node.nodes.forEach((n) => {
     if (n.object === 'text' && n.text.length > 0) {
       handleText(n, content);
-    } else if (n.object === 'inline') {
+      // Don't save inlines with empty text content inside
+    } else if (n.object === 'inline' && !isInlineEmpty(n)) {
       handleInline(n, content);
     }
   });

--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -35,7 +35,6 @@ function translateNode(node: Block, seenIds: Object) {
   node.nodes.forEach((n) => {
     if (n.object === 'text' && n.text.length > 0) {
       handleText(n, content);
-      // Don't save inlines with empty text content inside
     } else if (n.object === 'inline') {
       handleInline(n, content);
     }

--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -33,7 +33,6 @@ function translateNode(node: Block, seenIds: Object) {
 
   // Process each child node
   node.nodes.forEach((n) => {
-    console.log('n', n)
     if (n.object === 'text' && n.text.length > 0) {
       handleText(n, content);
       // Don't save inlines with empty text content inside


### PR DESCRIPTION
**Problem**:
This is a fairly serious problem where if a slate `inline` is saved with empty text content, it can cause the course build to fail. For example, OLI validates links to make sure they have a clickable "target" text, but Echo has no problem saving link elements with empty child text.

To reproduce:
1. Highlight text in a workbook page
2. Use the toolbar to create a `link` with the selection
3. Reselect the link text
4. Delete the text
5. Wait for the changes to propagate to SVN and then full preview the course

**Solution**:
Don't save content-based inlines with empty text contents. Content-based inlines are the code-highlighted inlines in this list:

- `Link`
- `Xref`
- `ActivityLink`
- `Quote`
- `Code`
- Cite
- Command
- Math
- Extra
- Image
- Sym
- InputRef

**Wireframe/Screenshot**:
None.

**Risk**:
High - core text persistence logic.

**Areas of concern**:
Simple change, no areas of concern as far as I can tell. I tested this with several different inline types in multiple locations throughout paragraphs.