### PR TITLE
0.38.0 - Re-arranging organization components not displaying in editor

### DIFF
--- a/src/editors/document/org/OrgComponentEditor.tsx
+++ b/src/editors/document/org/OrgComponentEditor.tsx
@@ -84,8 +84,13 @@ export class OrgComponentEditor
 
   componentWillReceiveProps(nextProps: OrgComponentEditorProps) {
     function isDifferentOrg(thisOrg, nextOrg) {
-      const thisOrgId = thisOrg.valueOr({ resource: {} }).resource.id;
-      return !thisOrgId || thisOrgId !== nextOrg.valueOr({ resource: {} }).resource.id;
+      const thisOrgResource = thisOrg.valueOr({ resource: {} }).resource;
+      if (!thisOrgResource) {
+        return true;
+      }
+      if (thisOrgResource !== nextOrg.valueOr({ resource: {} }).resource) {
+        return true;
+      }
     }
     if (this.props.componentId !== nextProps.componentId
       || isDifferentOrg(this.props.org, nextProps.org)) {


### PR DESCRIPTION
https://olidev.atlassian.net/browse/AUTHORING-2173

This PR is to fix a regression caused by another change on sprint 38. If you drag and drop organization components to re-order them, the new order doesn't show up in the main window. This was caused by a previous change in `componentWillReceiveProps` in the same component. I changed it to only update when a new organization ID was passed in through props to prevent the analytics page from constantly making new requests, but the organization ID is too narrow. If structural changes are made to the org (like re-arrangement), the ID will be the same but the reference to the organization resource will change, so I changed the comparison to check that instead.
