### PR TITLE
0.38.0 - "Simple Select" on questions to select correct answer not working

### DIFF
--- a/src/reducers/documents.ts
+++ b/src/reducers/documents.ts
@@ -177,9 +177,11 @@ export const documents = (
       // Else we are setting the node, so also set the corresponding page
       const node = action.nodeOrPageId;
       const currentPage = assessment.modelType === 'AssessmentModel'
-        ? assessment.pages.reduce(
+        ? assessment.pages.toArray().reduce(
           (activePage, page: contentTypes.Page) =>
-            page.nodes.contains(node) ? Maybe.just(page.guid) : activePage,
+            page.nodes.toArray().includes(node)
+              ? Maybe.just(page.guid)
+              : activePage,
           ed.currentPage)
         : Maybe.nothing<string>();
       const currentNode = Maybe.just(node);


### PR DESCRIPTION
https://olidev.atlassian.net/browse/AUTHORING-2176

If you use the "simple select" feature on some assessment questions to select the correct answer rather than manually entering a score, you get the `monad stack overflow` error we keep seeing. I tracked down where it was throwing and it turned out to be in the `SetActiveNodeOrPage` clause of the `documents` reducer, where we've seen this issue before.

I changed each of the data structures used in the section that was failing to convert to plain javascript arrays instead of using immutable js, and it fixed the issue. But I don't understand why this part of the codebase keeps triggering that error.