### PR TITLE
Authoring 2186 focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
@@ -113,8 +113,7 @@ class ContiguousTextEditor
       || this.props.editMode !== nextProps.editMode
       || this.state.value !== nextState.value
       || nextProps.selectedEntity !== this.props.selectedEntity
-      || nextProps.orderedIds !== this.props.orderedIds
-      || this.props.hover !== nextProps.hover;
+      || nextProps.orderedIds !== this.props.orderedIds;
   }
 
   renderSidebar() {


### PR DESCRIPTION
This PR fixes the issue where on a large workbook page simply hovering one's mouse over different contiguous text editors causes focus changes and scrolling - leading to a "jumping around" effect that is quite distracting and annoying. 

The solution was to remove the re-render of the CTE when the hover changes. 

RISK: Low
STABILITY: High, tested locally and on shattrath
