### PR TITLE
fix parsing metadata and prefs

### DIFF
--- a/src/data/content/metadata.ts
+++ b/src/data/content/metadata.ts
@@ -45,8 +45,13 @@ export class MetaData extends Immutable.Record({
   }
 
   toPersistence(): Object {
+    // `authors` must be an array for the server to correctly parse it
+    const authors = Array.isArray(this.authors)
+      ? this.authors
+      : [...this.authors];
+
     return {
-      authors: this.authors,
+      authors,
       license: this.license,
       copyright: this.copyright,
       keywords: this.keywords,

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -201,7 +201,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
       svnLocation: c.svnLocation,
       deploymentStatus: c.deploymentStatus,
       dateCreated: parseDate(c.dateCreated),
-      options: JSON.stringify(c.options),
+      options: c.options,
       icon: new contentTypes.WebContent(),
       theme: c.theme,
       activeDataset: c.activeDataset,
@@ -217,6 +217,15 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
   }
 
   toPersistence(): Object {
+    // Fix an bug where we converted preferences to a string in echo.
+    // It should be an object.
+    let preferences = this.options;
+    try {
+      if (typeof this.options === 'string') {
+        preferences = JSON.parse(this.options);
+      }
+    } catch (e) { }
+
     const doc = [{
       package: {
         '@id': this.id,
@@ -226,7 +235,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
         '@version': this.version,
         metadata: this.metadata.toPersistence(),
         description: this.description,
-        preferences: this.options,
+        preferences,
         misc: { language: this.language || 'en_US' },
       },
     }];
@@ -241,6 +250,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
       deploymentStatus: this.deploymentStatus,
       doc,
     };
+
     return Object.assign({}, values);
   }
 }


### PR DESCRIPTION
**Problem**:
Several older courses that were recently brought into Echo cause errors when their package information (course title, description, etc.) is changed.

List of courses:
- Oracle 101
- Procurement Card Application
- Finance Fundamentals
- Purchase Card Refresher Training (CMU Finance)

An error was thrown when parsing the `preferences` on the package, which was initially used as part of the **Foreign** content item and thought to be the source of this problem.

**Solution**:
After investigating, there were actually three separate small problems, none of which were related to the **Foreign** element changes:
1. Echo was converting the package `preferences` to a string on the client
2. The server could not handle empty preferences objects
3. The `authors` field of package `Metadata` must be an array

No other courses really use these package attributes, so I doubt these code paths were ever really tested.

**Wireframe/Screenshot**:
None.

**Risk**:
Low - only affects rarely used package fields.

**Areas of concern**:
Tested editing package title on 3 of the 4 courses. The 4th could not be imported into my local environment.