### PR TITLE
HOTFIX 0.38.2: Fix REPL creation issue

### DIFF
--- a/src/editors/content/learning/repl/ReplEditor.tsx
+++ b/src/editors/content/learning/repl/ReplEditor.tsx
@@ -97,7 +97,7 @@ const questionFromModel = (model: EmbedActivityModel) => {
   return q1 && {
     id: q1.getAttribute('id'),
     initeditortext: $('initeditortext', q1).text().trim(),
-    language: $('language', q1).text().trim(),
+    language: $('language', q1).text().trim() || 'python',
     functionname: $('functionname', q1).text().trim(),
     testCases: $('testcase', q1).map(function () {
       return {


### PR DESCRIPTION
This PR fixes and issue when creating a REPL activity in the editor, it will not have questions yet and therefore the REPL editor cannot determine what time of REPL to instantiate. This causes the REPL to show an error message making it unusable.

Steps to reproduce:
1. Create new REPL activity
2. Enter REPL activity
3. Exit, REPL activity and then reenter

REPLEditor should simply default to python, for now

**Risk**: Low, targeted
**Stability**: Tested, stable
