### PR TITLE
ignore empty marks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -117,6 +117,15 @@ function isNestedMark(item: Object): boolean {
   return item['#text'] === undefined;
 }
 
+// Given a style mark object, determine if it is empty, that is it
+// contains no actual text and no nested mark.
+function isEmptyMark(item: Object): boolean {
+
+  // A mark object is empty if it only contains attributes or is empty.
+  // In other words, it is missing #text and it is missing a nested element.
+  return Object.keys(item).filter(k => !k.startsWith('@')).length === 0;
+}
+
 // Create a slate mark from a persisted from a mark element. For em elements,
 // we use 'em' as the mark style for bold, all other em styles we use
 // the style name. sub, sup and other non em styles are just their
@@ -318,16 +327,21 @@ function processMark(item: Object,
   //   }
   // }
   //
-  if (isNestedMark(item)) {
-    processMark(getChildren(item)[0], parent, previousMarks.push(getMark(item)));
-    return;
-  }
 
-  parent.nodes.push({
-    object: 'text',
-    text: item['#text'],
-    marks: previousMarks.toArray(),
-  });
+  if (!isEmptyMark(item)) {
+
+    if (isNestedMark(item)) {
+      processMark(getChildren(item)[0], parent, previousMarks.push(getMark(item)));
+      return;
+    }
+
+    parent.nodes.push({
+      object: 'text',
+      text: item['#text'],
+      marks: previousMarks.toArray(),
+    });
+
+  }
 }
 
 function extractId(item: any): Object {


### PR DESCRIPTION
This PR fixes the ability to handle resources that contain empty inline markup elements, such as &lt;sub&gt;&lt;/sub&gt; or &lt;em style="italic" &gt;&lt;/em&gt; 
Currently the editor will not load resource that contains these types of elements. 

The solution here is to detect the empty element and simply ignore it.

STABILITY: High, tested locally with several pages that contain this issue and it fixes the problem.
RISK: Low/medium: fairly isolated, but this is in the core parsing code

