### PR TITLE
Authoring 2210 code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/contiguous.ts
+++ b/src/data/content/learning/contiguous.ts
@@ -62,6 +62,7 @@ export enum InlineStyles {
   Subscript = 'sub',
   Superscript = 'sup',
   BidirectionTextOverride = 'bdo',
+  Code = 'code',
 }
 
 export enum InlineEntities {

--- a/src/data/content/learning/slate/topersistence.ts
+++ b/src/data/content/learning/slate/topersistence.ts
@@ -74,6 +74,7 @@ function handleText(node: Text, content) {
 // Handler for a text node that contains one or more marks
 function handleMarkedText(node: Text, content) {
   const isBdo = (m: Mark) => m.type === 'bdo';
+  const isCode = (m: Mark) => m.type === 'code';
   const isForeign = (m: Mark) => m.type === 'foreign';
 
   // const marks = node.marks.toArray().map(m => m.type);
@@ -81,9 +82,14 @@ function handleMarkedText(node: Text, content) {
 
   // if bdo is present, it must be the first element that
   // we place in the OLI JSON.  This is a DTD constraint.
-  const adjustedMarks = marks.some(isBdo)
+  let adjustedMarks = marks.some(isBdo)
     ? [Mark.create({ type: 'bdo' }), ...marks.filter(m => !isBdo(m))]
     : marks;
+
+  // Ultimately, code elements have to be the outermost (even more so than bdo)
+  adjustedMarks = adjustedMarks.some(isCode)
+    ? [Mark.create({ type: 'code' }), ...adjustedMarks.filter(m => !isCode(m))]
+    : adjustedMarks;
 
   const root = { root: {} };
   let last = root;
@@ -164,6 +170,7 @@ const styleContainers = {
   foreign: () => ({ foreign: {} }),
   sub: () => ({ sub: {} }),
   sup: () => ({ sup: {} }),
+  code: () => ({ code: {} }),
 };
 
 // The handlers for the items that we represent as slate inlines.
@@ -174,7 +181,6 @@ const inlineHandlers = {
   Xref: contentBasedInline,
   ActivityLink: contentBasedInline,
   Quote: contentBasedInline,
-  Code: contentBasedInline,
   Math: terminalInline,
   Extra: subElementInlineHandler.bind(undefined, 'extra', 'anchor'),
   Image: terminalInline,

--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -7,7 +7,7 @@ import { Value, ValueJSON, BlockJSON, InlineJSON, MarkJSON, Data, Mark } from 's
 
 // The elements that we handle as slate marks
 const marks = Immutable.Set<string>(
-  ['foreign', 'ipa', 'sub', 'sup', 'term', 'bdo', 'var', 'em']);
+  ['foreign', 'ipa', 'sub', 'sup', 'term', 'bdo', 'var', 'em', 'code']);
 
 // The elements that are handled as slate inlines, and their corresponding
 // handlers.
@@ -18,7 +18,6 @@ const inlineHandlers = {
   activity_link: contentBasedInline,
   input_ref: inputRef,
   quote: contentBasedInline,
-  code: contentBasedInline,
   formula: stripOutInline,
   'm:math': terminalInline,
   '#math': terminalInline,

--- a/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextToolbar.tsx
@@ -288,7 +288,7 @@ class ContiguousTextToolbar
 
     return (
       <ToolbarGroup
-        label="Text Block" highlightColor={CONTENT_COLORS.ContiguousText} columns={13.4}>
+        label="Text Block" highlightColor={CONTENT_COLORS.ContiguousText} columns={14.4}>
         <ToolbarLayout.Inline>
           <ToolbarButton
             onClick={
@@ -351,8 +351,17 @@ class ContiguousTextToolbar
             }
             disabled={!supports('var') || !editMode}
             selected={styles.has('var')}
+            tooltip="Variable">
+            <i className={'fa fa-heading'} />
+          </ToolbarButton>
+          <ToolbarButton
+            onClick={
+              () => this.props.editor.lift(e => editorUtils.toggleMark(e, InlineStyles.Code))
+            }
+            disabled={!supports('code') || !editMode}
+            selected={styles.has('code')}
             tooltip="Code">
-            {getContentIcon(insertableContentTypes.BlockCode)}
+            <i className={'fa fa-code'} />
           </ToolbarButton>
           <ToolbarButton
             onClick={

--- a/src/editors/content/learning/contiguoustext/render/render.tsx
+++ b/src/editors/content/learning/contiguoustext/render/render.tsx
@@ -49,6 +49,8 @@ export function renderBlock(props, editor, next) {
 // Slate mark rendering
 export function renderMark(props, editor, next) {
   switch (props.mark.type) {
+    case 'code':
+      return <code>{props.children}</code>;
     case 'sub':
       return <sub>{props.children}</sub>;
     case 'sup':
@@ -98,8 +100,6 @@ export function renderInline(extras, props, editor: Editor, next) {
   switch (node.type) {
     case 'Cite':
       return <CiteDisplay {...standardProps} />;
-    case 'Code':
-      return <code {...attributes}>{children}</code>;
     case 'Link': {
       return tip('External Hyperlink', 'oli-link', attributes, children);
     }

--- a/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
@@ -37,6 +37,8 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
 
   save(doc: persistence.Document) {
 
+    return;
+
     this.pending = doc;
 
     if (this.stateChangeCallback !== null) {

--- a/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
+++ b/src/editors/manager/persistence/DeferredPersistenceStrategy.ts
@@ -37,8 +37,6 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
 
   save(doc: persistence.Document) {
 
-    return;
-
     this.pending = doc;
 
     if (this.stateChangeCallback !== null) {


### PR DESCRIPTION
This PR fixes the fact that the editor is stripping out inline code elements from pages.

The root cause was how the blockcode type was not wired up correctly.  I took this opportunity to instead treat code inlines as marks, which simplifies the implementation.

I also added the ability to create code inlines via the toolbar (previously we called the "var" element "Code").

RISK: Medium
STABILITY: High, testing shows that it works