### PR TITLE
HOTFIX 0.40.1 - Fix text editing in CTEs in Safari

### DIFF
--- a/src/components/sidebar/ContextAwareSidebar.controller.ts
+++ b/src/components/sidebar/ContextAwareSidebar.controller.ts
@@ -18,7 +18,6 @@ import { CombinationsMap } from 'types/combinations';
 import { computeCombinations } from 'actions/choices';
 import { duplicate } from 'actions/duplication';
 import { CourseState } from 'reducers/course';
-import { Value } from 'slate';
 
 interface StateProps {
   content: Maybe<ContentElement>;

--- a/src/data/content/learning/contiguous.ts
+++ b/src/data/content/learning/contiguous.ts
@@ -4,7 +4,6 @@ import { Maybe } from 'tsmonad';
 import { augment } from 'data/content/common';
 import guid from 'utils/guid';
 import { Value, Block, Inline } from 'slate';
-import Html from 'slate-html-serializer';
 import { toSlate } from 'data/content/learning/slate/toslate';
 import { toPersistence } from 'data/content/learning/slate/topersistence';
 

--- a/src/editors/content/common/InputList.scss
+++ b/src/editors/content/common/InputList.scss
@@ -3,8 +3,6 @@
 @import 'oli/zindex';
 
 .input-list {
-  @include disable-select;
-
   .input-list-item {
     display: flex;
     flex-direction: row;
@@ -41,7 +39,6 @@
         display: flex;
         flex-direction: row;
       }
-
     }
 
     .input-list-item-content {

--- a/src/editors/content/content/ContentEditor.scss
+++ b/src/editors/content/content/ContentEditor.scss
@@ -9,15 +9,15 @@
     flex-direction: row;
     font-size: 0.8rem;
     padding-top: 15px;
+
     @include disable-select;
 
     select {
-      margin-top: -5px
+      margin-top: -5px;
     }
   }
 
   .content-body {
     margin: 15px 0;
-    @include disable-select;
   }
 }

--- a/src/editors/content/feedback/common.scss
+++ b/src/editors/content/feedback/common.scss
@@ -1,82 +1,78 @@
-@import "oli/colors";
-@import "oli/mixins";
+@import 'oli/colors';
+@import 'oli/mixins';
 
 .feedback-question-editor {
-    padding: 0 10px 0 30px;
+  padding: 0 10px 0 30px;
 
-    .question-body {
-        margin: 15px 0;
-
-        @include disable-select;
-    }
+  .question-body {
+    margin: 15px 0;
+  }
 }
 
 .feedback-title {
-    display: flex;
-    flex-direction: row;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #ddd;
-    line-height: 31px;
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #ddd;
+  line-height: 31px;
 
-    @include disable-select;
+  .title {
+    font-size: 1.3em;
+  }
 
-    .title {
-        font-size: 1.3em;
+  .action-btn {
+    cursor: pointer;
+
+    i {
+      padding: 6px;
     }
 
-    .action-btn {
-        cursor: pointer;
-
+    &.action-btn-duplicate {
+      &:hover {
         i {
-            padding: 6px;
+          color: darken($selection, 10%);
         }
+      }
 
-        &.action-btn-duplicate {
-            &:hover {
-                i {
-                    color: darken($selection, 10%);
-                }
-            }
-
-            &:active {
-                i {
-                    color: darken($selection, 15%);
-                }
-            }
-
-            &.disabled {
-                cursor: default;
-
-                &, &:hover, &:active {
-                    i {
-                        color: $gray;
-                    }
-                }
-            }
+      &:active {
+        i {
+          color: darken($selection, 15%);
         }
+      }
 
-        &.action-btn-remove {
-            &:hover {
-                i {
-                    color: darken($remove, 10%);
-                }
-            }
+      &.disabled {
+        cursor: default;
 
-            &:active {
-                i {
-                    color: darken($remove, 15%);
-                }
-            }
-
-            &.disabled {
-                cursor: default;
-
-                &, &:hover, &:active {
-                    i {
-                        color: $gray;
-                    }
-                }
-            }
+        &, &:hover, &:active {
+          i {
+            color: $gray;
+          }
         }
+      }
     }
+
+    &.action-btn-remove {
+      &:hover {
+        i {
+          color: darken($remove, 10%);
+        }
+      }
+
+      &:active {
+        i {
+          color: darken($remove, 15%);
+        }
+      }
+
+      &.disabled {
+        cursor: default;
+
+        &, &:hover, &:active {
+          i {
+            color: $gray;
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
@@ -29,10 +29,8 @@ const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
 const mapDispatchToProps = (dispatch, ownProps): DispatchProps => {
 
   return {
-    onUpdateEditor: editor => {
-      console.log('onUpdateEditor (controller)', editor);
-      dispatch(updateEditor(editor));
-    },
+    onUpdateEditor: editor =>
+      dispatch(updateEditor(editor)),
 
     onSelectInline: inline =>
       dispatch(selectInline(inline)),

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.controller.ts
@@ -26,15 +26,18 @@ const mapStateToProps = (state, ownProps: OwnProps): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch, getState): DispatchProps => {
+const mapDispatchToProps = (dispatch, ownProps): DispatchProps => {
 
   return {
-    onUpdateEditor: editor =>
-      dispatch(updateEditor(editor)),
+    onUpdateEditor: editor => {
+      console.log('onUpdateEditor (controller)', editor);
+      dispatch(updateEditor(editor));
+    },
+
     onSelectInline: inline =>
       dispatch(selectInline(inline)),
-    onInsertParsedContent: (
-      resourcePath: string, content: ParsedContent) =>
+
+    onInsertParsedContent: (resourcePath: string, content: ParsedContent) =>
       dispatch(insertParsedContent(resourcePath, content)),
   };
 };

--- a/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
+++ b/src/editors/content/learning/contiguoustext/ContiguousTextEditor.tsx
@@ -49,11 +49,6 @@ class ContiguousTextEditor
   }
 
   onChange = ({ value }) => {
-    console.log('ContiguousTextEditor.onChange, value:', value);
-    // if (this.state.value === value) {
-    // return;
-    // }
-
     const v: Value = value;
 
     const edited = v.document !== this.state.value.document;
@@ -69,19 +64,16 @@ class ContiguousTextEditor
         this.props.onEdit(updated, updated);
 
         // We must always broadcast the latest version of the editor
-        console.log('Edited value -> calling onUpdateEditor');
         this.props.onUpdateEditor(this.editor);
         this.editor.focus();
 
         // Do not broadcast changes if the editor is unfocused (de-selected)
       } else if (updateSelection && !v.selection.isFocused) {
-        console.log('Not focused -> returning');
         return;
 
       } else if (updateSelection) {
 
         // Broadcast the fact that the editor updated
-        console.log('Updated selection -> calling onUpdateEditor');
         this.props.onUpdateEditor(this.editor);
 
         // Based on the new selection, update whether or not
@@ -102,38 +94,16 @@ class ContiguousTextEditor
     // as that is a signal to us that something external has changed the
     // content and we must pull it down into state to rerender.
     if (this.props.model.forcedUpdateCount !== nextProps.model.forcedUpdateCount) {
-      console.log('componentWillReceiveProps - Setting state with new value', nextProps.model.slateValue);
       this.setState({ value: nextProps.model.slateValue });
     }
   }
 
-  shouldComponentUpdate(
-    nextProps: Props, nextState: State) {
-    const a = this.props.model.forcedUpdateCount !== nextProps.model.forcedUpdateCount;
-    const b = this.props.editMode !== nextProps.editMode;
-    const c = this.state.value !== nextState.value;
-    const d = nextProps.selectedEntity !== this.props.selectedEntity;
-    const e = nextProps.orderedIds !== this.props.orderedIds;
-
-    if (a || b || c || d || e) {
-      console.log('shouldComponentUpdate - rerendering');
-      if (a) {
-        console.log('(Forced update count different)');
-      }
-      if (b) {
-        console.log('(edit mode different)');
-      }
-      if (c) {
-        console.log('(state value different', this.state.value, nextState.value, ')');
-      }
-      if (d) {
-        console.log('(selected entity different', this.props.selectedEntity, nextProps.selectedEntity, ')');
-      }
-      if (e) {
-        console.log('(orderedIds different)');
-      }
-    }
-    return a || b || c || d || e;
+  shouldComponentUpdate(nextProps: Props, nextState: State) {
+    return this.props.model.forcedUpdateCount !== nextProps.model.forcedUpdateCount
+      || this.props.editMode !== nextProps.editMode
+      || this.props.selectedEntity !== nextProps.selectedEntity
+      || this.props.orderedIds !== nextProps.orderedIds
+      || this.state.value !== nextState.value;
   }
 
   renderSidebar() {
@@ -150,14 +120,8 @@ class ContiguousTextEditor
   }
 
   slateOnFocus = (e) => {
-    console.log('Event', e);
-    console.log('(1) ContiguousTextEditor -> calling onUpdateEditor with ', this.editor);
     this.props.onUpdateEditor(this.editor);
-    console.log('(2) ContiguousTextEditor -> calling onFocus with ', this.props.model, this.props.parent);
     this.props.onFocus(this.props.model, this.props.parent, Maybe.nothing());
-    console.log('this editor value in slateOnFocus:', this.editor.value);
-    // this.setState({ value: this.editor.value });
-
   }
 
   onPaste = (event, editor: EditorCore, next) => {
@@ -195,8 +159,6 @@ class ContiguousTextEditor
       parentProps: this.props,
       parent: this,
     };
-
-    console.log('State selection', this.state.value.selection);
 
     return (
       <div

--- a/src/editors/content/part/ChoiceFeedback.scss
+++ b/src/editors/content/part/ChoiceFeedback.scss
@@ -2,8 +2,6 @@
 @import 'oli/mixins';
 
 .choice-feedback {
-  @include disable-select;
-
   .feedback-items {
     .response {
       margin-bottom: 25px;

--- a/src/editors/content/part/Feedback.scss
+++ b/src/editors/content/part/Feedback.scss
@@ -2,8 +2,6 @@
 @import 'oli/mixins';
 
 .feedback {
-  @include disable-select;
-
   .feedback-items {
     .response {
       margin-bottom: 25px;

--- a/src/editors/content/question/ordering/Ordering.scss
+++ b/src/editors/content/question/ordering/Ordering.scss
@@ -2,8 +2,6 @@
 @import 'oli/mixins';
 
 .ordering-feedback {
-  @include disable-select;
-
   .feedback-items {
     .response {
       margin-bottom: 25px;
@@ -25,7 +23,7 @@
   .order-selection {
     border-radius: 4px;
     background-color: #E7F4FE;
-    box-shadow: 2px 2px 10px 0px rgba(155,165,173,1);
+    box-shadow: 2px 2px 10px 0px rgba(155, 165, 173, 1);
     padding: 5px 10px;
 
     .input-list-item-content {

--- a/src/editors/content/question/question/QuestionEditor.scss
+++ b/src/editors/content/question/question/QuestionEditor.scss
@@ -9,7 +9,6 @@
     flex-direction: row;
     padding-bottom: 10px;
     border-bottom: 1px solid #ddd;
-    @include disable-select;
 
     .title {
       font-size: 1.3em;
@@ -50,11 +49,6 @@
         }
       }
     }
-  }
-
-  .question-content {
-    padding: 0 10px;
-    @include disable-select;
   }
 
   .item-part-editor {

--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -511,6 +511,7 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
 
   onFocus = (
     model: ContentElement, parent: ParentContainer, textSelection: Maybe<TextSelection>) => {
+    console.log('onFocus -- AssessmentEditor', model);
     this.props.onUpdateContentSelection(
       this.props.context.documentId, model, parent, textSelection);
   }

--- a/src/editors/document/assessment/AssessmentEditor.tsx
+++ b/src/editors/document/assessment/AssessmentEditor.tsx
@@ -509,9 +509,8 @@ export default class AssessmentEditor extends AbstractEditor<models.AssessmentMo
     );
   }
 
-  onFocus = (
-    model: ContentElement, parent: ParentContainer, textSelection: Maybe<TextSelection>) => {
-    console.log('onFocus -- AssessmentEditor', model);
+  onFocus = (model: ContentElement, parent: ParentContainer,
+    textSelection: Maybe<TextSelection>) => {
     this.props.onUpdateContentSelection(
       this.props.context.documentId, model, parent, textSelection);
   }

--- a/src/editors/document/common/questions.scss
+++ b/src/editors/document/common/questions.scss
@@ -1,63 +1,61 @@
-@import "oli/colors";
-@import "oli/mixins";
+@import 'oli/colors';
+@import 'oli/mixins';
 
 .node-container {
-    overflow: auto;
-    flex: 1 1 auto;
+  overflow: auto;
+  flex: 1 1 auto;
 }
 
 .feedback-question {
-    .options {
-        display: flex;
-        flex-direction: row;
-        font-size: 0.8rem;
-        padding-top: 15px;
+  .options {
+    display: flex;
+    flex-direction: row;
+    font-size: 0.8rem;
+    padding-top: 15px;
 
-        @include disable-select;
+    & > * {
+      display: flex;
+      flex-direction: row;
+    }
 
-        & > * {
-            display: flex;
-            flex-direction: row;
+    .option,
+    .control {
+      .control-label {
+        margin: 0 10px;
+      }
+
+      &.clickable {
+        cursor: pointer;
+      }
+
+      select {
+        margin-top: -5px;
+      }
+
+      &:first-child {
+        .control-label {
+          margin-left: 0;
         }
-
-        .option,
-        .control {
-            .control-label {
-                margin: 0 10px;
-            }
-
-            &.clickable {
-                cursor: pointer;
-            }
-
-            select {
-                margin-top: -5px;
-            }
-
-            &:first-child {
-                .control-label {
-                    margin-left: 0;
-                }
-            }
-        }
+      }
     }
+  }
 
-    .question-body {
-        margin: 15px 0;
-    }
+  .question-body {
+    margin: 15px 0;
+  }
 
-    .instruction-label {
-        font-size: 0.9rem;
-        color: $gray-dark;
-        padding-bottom: 15px;
-    }
+  .instruction-label {
+    font-size: 0.9rem;
+    color: $gray-dark;
+    padding-bottom: 15px;
+  }
 }
 
 .variableHeader {
-    flex: 1;
-    display: inline-block;
+  flex: 1;
+  display: inline-block;
 }
 
 .variable-wrapper {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }

--- a/src/editors/document/workbook/WorkbookPageEditor.tsx
+++ b/src/editors/document/workbook/WorkbookPageEditor.tsx
@@ -231,6 +231,7 @@ class WorkbookPageEditor extends AbstractEditor<models.WorkbookPageModel,
   }
 
   onFocus(model, parent, textSelection) {
+    console.log('onFocus - WorkbookPageEditor', model);
     this.props.onUpdateContentSelection(
       this.props.context.documentId, model, parent, textSelection);
   }

--- a/src/editors/document/workbook/WorkbookPageEditor.tsx
+++ b/src/editors/document/workbook/WorkbookPageEditor.tsx
@@ -231,7 +231,6 @@ class WorkbookPageEditor extends AbstractEditor<models.WorkbookPageModel,
   }
 
   onFocus(model, parent, textSelection) {
-    console.log('onFocus - WorkbookPageEditor', model);
     this.props.onUpdateContentSelection(
       this.props.context.documentId, model, parent, textSelection);
   }

--- a/src/reducers/active.ts
+++ b/src/reducers/active.ts
@@ -30,7 +30,6 @@ export const activeContext = (
       });
 
     case actions.UPDATE_EDITOR:
-      console.log('UPDATE_EDITOR - active reducer, editor is', action.editor);
       return state.with({
         activeInline: Maybe.nothing(),
         editor: Maybe.maybe(action.editor),
@@ -43,7 +42,6 @@ export const activeContext = (
       });
 
     case actions.UPDATE_CONTEXT:
-      console.log('UPDATE_CONTEXT - active reducer, activeChild is', action.content, 'container is', action.container);
       return state.with({
         activeChild: Maybe.maybe(action.content),
         container: Maybe.maybe(action.container),

--- a/src/reducers/active.ts
+++ b/src/reducers/active.ts
@@ -28,42 +28,36 @@ export const activeContext = (
       return state.with({
         activeInline: action.inline,
       });
+
     case actions.UPDATE_EDITOR:
+      console.log('UPDATE_EDITOR - active reducer, editor is', action.editor);
       return state.with({
         activeInline: Maybe.nothing(),
-        editor: action.editor === null || action.editor === undefined
-          ? Maybe.nothing() : Maybe.just(action.editor),
+        editor: Maybe.maybe(action.editor),
       });
+
     case actions.UPDATE_CONTENT:
       return state.with({
-        activeChild: action.content === null || action.content === undefined
-          ? Maybe.nothing() : Maybe.just(action.content),
+        activeChild: Maybe.maybe(action.content),
         documentId: Maybe.just(action.documentId),
       });
+
     case actions.UPDATE_CONTEXT:
+      console.log('UPDATE_CONTEXT - active reducer, activeChild is', action.content, 'container is', action.container);
       return state.with({
-        activeChild: action.content === null || action.content === undefined
-          ? Maybe.nothing() : Maybe.just(action.content),
-        container: action.container === null || action.container === undefined
-          ? Maybe.nothing() : Maybe.just(action.container),
+        activeChild: Maybe.maybe(action.content),
+        container: Maybe.maybe(action.container),
         documentId: Maybe.just(action.documentId),
       });
+
     case documentActions.DOCUMENT_RELEASED:
-      return state.with({
-        activeInline: Maybe.nothing(),
-        activeChild: Maybe.nothing(),
-        container: Maybe.nothing(),
-        documentId: Maybe.nothing(),
-        editor: Maybe.nothing(),
-      });
+      return new ActiveContext();
+
     case documentActions.DOCUMENT_LOADED:
-      return state.with({
-        activeInline: Maybe.nothing(),
-        activeChild: Maybe.nothing(),
-        container: Maybe.nothing(),
+      return new ActiveContext({
         documentId: Maybe.just(action.documentId),
-        editor: Maybe.nothing(),
       });
+
     case actions.RESET_ACTIVE:
     case documentActions.CHANGE_UNDONE:
     case documentActions.CHANGE_REDONE:


### PR DESCRIPTION
**Problem**:
Some assessment contiguous text editors cannot be selected in Safari, so the text cannot be edited.

Affects:
- supporting content
- choice text
- feedback text

**Solution**:
The `@include disable-select` mixin which sets the `user-select: none` on the `div`s surrounding the CTEs was preventing user selection. I removed the mixin from the areas with the problem.

I also made a small refactor to clean up the `active` reducer while I was trying to figure out what the issue was. Originally I thought the redux state might not be updated correctly, but that wasn't the problem.

**Wireframe/Screenshot**:
None.

**Risk**:
Low - CSS changes, reducer refactor is small and was tested.

**Areas of concern**:
Not sure why this issue came up to begin with, the css properties have been set that way for 2 years.