### PR TITLE
HOTFIX 0.40.2 - AUTHORING-2222 fix REPL activity width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/content/learning/repl/repl_assets.ts
+++ b/src/editors/content/learning/repl/repl_assets.ts
@@ -83,7 +83,7 @@ Copyright (c) 2019 Carnegie Mellon University.
 /* The console container element */
 #console {
   height: 250px;
-  width: 335px;
+  width: 50%;
   position:relative;
   background-color: black;
   border: 2px solid #CCC;
@@ -93,11 +93,11 @@ Copyright (c) 2019 Carnegie Mellon University.
   left: 0;
 }
 #console.console-only {
-  width: 670px;
+  width: 100%;
 }
 #editor {
   height: 250px;
-  width: 335px;
+  width: 50%;
   border: 2px solid #CCC;
   position:relative;
   display: inline-block;


### PR DESCRIPTION
This PR fixes an issue where REPL activities are embedded within Example and the width of the superactivity may be smaller than normal

**Risk**: Low, style only and only affects REPLs
**Stability**: Tested and is stable