### PR TITLE
HOTFIX 0.41.1 - Uptick Version for Server Change

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "jsx-loader": "^0.13.2",
     "react-hot-loader": "^4.12.15",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.7.5"
+    "typescript": "3.7.5"
   },
   "jest": {
     "verbose": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",


### PR DESCRIPTION
Uptick the version shown to users on the client for a server hotfix.

Also pin the Typescript version to 3.7.5 to prevent compilation errors from the new version.