### PR TITLE
prevent a duplicate skill from being created

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",


### PR DESCRIPTION
This PR applies a band-aid to skill editing to address a problem where skills with duplicate ids are getting added - which triggers a server side validation failure. 

The fix here assumes the problem is manifesting with a skill with a new guid, yet the same id.  So using the guid directly to update the skills collection would lead to a duplicate id.  Instead, we use the id of the updated model to find an existing skill.  

RISK: Low, tested locally and everything still works
STABILITY: Unknown if it provides full protection against the unknown root cause

