### PR TITLE
keep guid and key in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",


### PR DESCRIPTION
This PR does actually address the skill renaming issue.  Debuggin locally revealed that the internal guid of a skill was getting out of sync with the guid used as the key in the outer orderedmap.

This PR prevents that from happening by not using the guid of the supplied edited skill, but rather it reuses the one that it finds in the current map. 

I suspect this problem could occur for objectives as well, so I applied the fix there also.

RISK: Low, tested and works well
STABILITY: With the davis course imported locally i  no longer see this problem 
