### PR TITLE
Authoring 2257 empty preferences bug

### DIFF
--- a/src/actions/media.ts
+++ b/src/actions/media.ts
@@ -106,7 +106,7 @@ export const fetchMediaReferences = (courseId: CourseIdVers) => (
               edgePathTo,
               (acc.get(edgePathTo) || List<MediaRef>()).concat({
                 resourceId: edge.sourceId.replace(/^.*:/, ''),
-                guid: edge.metadata.jsonObject.sourceGuid,
+                guid: edge.metadata.sourceGuid,
               }) as List<MediaRef>,
             );
           },

--- a/src/components/objectives/ObjectiveSkillView.tsx
+++ b/src/components/objectives/ObjectiveSkillView.tsx
@@ -43,13 +43,13 @@ import { ToggleSwitch } from 'components/common/ToggleSwitch';
 const getQuestionRefFromSkillEdge = (
   edge: Edge, assessmentType: LegacyTypes, assessmentId: string): Maybe<QuestionRef> => {
   return getQuestionRefFromPathInfo(
-    edge.metadata.jsonObject.pathInfo, assessmentType, assessmentId);
+    edge.metadata.pathInfo, assessmentType, assessmentId);
 };
 
 const getPoolInfoFromPoolRefEdge = (edge: Edge, questionCount: number): Maybe<PoolInfo> => {
   if (!edge) return Maybe.nothing();
 
-  const pathInfo = edge.metadata.jsonObject.pathInfo;
+  const pathInfo = edge.metadata.pathInfo;
   return Maybe.just({
     questionCount,
     count: pathInfo.parent['@count'],

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -149,14 +149,14 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
     const c = json as any;
 
     const metadata =
-      isNullOrUndefined(c.metadata.jsonObject)
+      isNullOrUndefined(c.metadata)
         ? new contentTypes.MetaData()
-        : contentTypes.MetaData.fromPersistence(c.metadata.jsonObject);
+        : contentTypes.MetaData.fromPersistence(c.metadata);
 
     const language =
-      isNullOrUndefined(c.misc) || isNullOrUndefined(c.misc.jsonObject)
+      isNullOrUndefined(c.misc) || isNullOrUndefined(c.misc)
         ? 'en_US'
-        : c.misc.jsonObject['language'];
+        : c.misc['language'];
 
     const resources =
       isNullOrUndefined(c.resources)

--- a/src/data/models/course.ts
+++ b/src/data/models/course.ts
@@ -154,7 +154,7 @@ export class CourseModel extends Immutable.Record(defaultCourseModel) {
         : contentTypes.MetaData.fromPersistence(c.metadata);
 
     const language =
-      isNullOrUndefined(c.misc) || isNullOrUndefined(c.misc)
+      isNullOrUndefined(c.misc)
         ? 'en_US'
         : c.misc['language'];
 

--- a/src/editors/document/analytics/Analytics.tsx
+++ b/src/editors/document/analytics/Analytics.tsx
@@ -252,7 +252,7 @@ class Analytics
     // using skill edges, create a Map<SkillId, List<QuestionRef>>
     const skillQuestionRefMap = skillEdges.reduce(
       (acc, edge) => getQuestionRefFromPathInfo(
-        edge.metadata.jsonObject.pathInfo,
+        edge.metadata.pathInfo,
         edge.sourceType,
         resourceId(edge.sourceId),
       ).caseOf({

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -18,10 +18,8 @@ export type Edge = {
   referenceType: string;
   status: string;
   metadata: {
-    jsonObject: {
-      pathInfo: PathElement;
-      sourceGuid: string;
-    };
+    pathInfo: PathElement;
+    sourceGuid: string;
   };
 };
 


### PR DESCRIPTION
This PR removes the "jsonObject" attribute from the Edge type "metadata" and "jsonObject" reference in the course package "metadata". Cleans up its usage of both in the rest of the code base.
