### PR TITLE
Authoring 2254 empty titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.41.6",
+  "version": "0.41.7",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/components/resourceview/ResourceView.tsx
+++ b/src/components/resourceview/ResourceView.tsx
@@ -317,6 +317,9 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
   renderCreation() {
     const { course, dispatch } = this.props;
     const { newItemTitle } = this.state;
+    const isTitleValid = newItemTitle.trim() !== '';
+    const validity = isTitleValid ? '' : 'is-invalid';
+    const titleClasses = `form-control mb-2 mr-sm-2 mb-sm-0 ${validity}`;
 
     return (
       <div className="table-toolbar">
@@ -330,13 +333,14 @@ export default class ResourceView extends React.Component<ResourceViewProps, Res
                 style={{ width: 300 }}
                 value={newItemTitle}
                 disabled={!course.editable}
-                className="form-control mb-2 mr-sm-2 mb-sm-0" id="inlineFormInput"
+                className={titleClasses}
+                id="inlineFormInput"
                 onChange={({ target: { value } }) => this.setState({ newItemTitle: value })}
                 placeholder="Enter title for new resource" />
               <div className="dropdown">
                 <button
                   style={{ height: 38, border: 'none' }}
-                  disabled={!course.editable || !newItemTitle}
+                  disabled={!course.editable || !isTitleValid}
                   className="btn btn-md btn-primary dropdown-toggle"
                   data-toggle="dropdown">{'Choose type... '}
                 </button>


### PR DESCRIPTION
This PR addresses the problem that a pool can be created with an empty title, which breaks the build.

This fix simply disallows resource creation with empty titles. 

It does not adjust title editing from within a resource editor (like a work book page editor), since attempts there to edit a title to empty already fail with a red banner warning.  Therefore, creation via the "All Resources" view is the only way to trigger this condition of the build being broken.

RISK: Low
STABILITY: High