### PR TITLE
Fix for authoring-2245 course sorting error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.41.7",
+  "version": "0.41.8",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -257,8 +257,8 @@ const CoursesViewSearchableTable = ({ rows, onSelect, searchText, serverTimeSkew
 
   const comparators = [
     (direction, a, b) => safeCompare('title', 'id', direction, a, b),
-    (direction, a, b) => safeCompare('id', 'title', direction, a, b),
     (direction, a, b) => safeCompare('version', 'title', direction, a, b),
+    (direction, a, b) => safeCompare('id', 'title', direction, a, b),
     (direction, a, b) => direction === SortDirection.Ascending
       ? compareDates(a.dateCreated, b.dateCreated)
       : compareDates(b.dateCreated, a.dateCreated),


### PR DESCRIPTION
This PR addresses the problem of the sorting in the courses view page.  The root cause was simply that the array of comparators for the inner sorted table were out of order with respect to the parallel array of column renderers. 

RISK: Low, fix isolated to just this view
STABILITY: High, tested interactively and fixes the problem 