### PR TITLE
Authoring 2296 switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/components/CoursesViewSearchable.tsx
+++ b/src/components/CoursesViewSearchable.tsx
@@ -235,10 +235,10 @@ const CoursesViewSearchableTable = ({ rows, onSelect, searchText, serverTimeSkew
     'Created',
   ];
 
+
+  const style = course => course.buildStatus !== 'READY' ? { pointerEvents: 'none', cursor: 'default' } : {};
   const link = course => span =>
-    <button disabled={course.buildStatus !== 'READY'}
-      onClick={() => onSelect(course.idvers)}
-      className="btn btn-link">{span}</button>;
+    <a href={'#/' + course.idvers} style={style(course) as any}>{span}</a>;
 
   const columnRenderers = [
     r => link(r)(highlightedColumnRenderer(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -271,8 +271,18 @@ class Header
     return <span>OLI Course Authoring</span>;
   }
 
+  isCourseRoute() {
+    return this.props.router.route.type === 'RouteCourse';
+  }
+
   render() {
     const { classes, router } = this.props;
+
+    // For our purposes, we need to know if the current route is either course-specific
+    // or application specific.  If course specific, we display the title of the package
+    // here in the header, otherwise for all other routes we display the application title
+    const label = this.isCourseRoute() && this.props.course
+    ? this.renderPackageTitle() : this.renderApplicationLabel();
 
     return (
       <div className={classNames(['Header', classes.Header])}>
@@ -286,7 +296,7 @@ class Header
               className="d-inline-block align-top" alt="" />
           </Link>
 
-          {this.props.course ? this.renderPackageTitle() : this.renderApplicationLabel()}
+          {label}
 
         </div>
         <ReactCSSTransitionGroup transitionName="saving"


### PR DESCRIPTION
This bug proved to be harder to solve than initially thought. As it turns out the behavior of "failure to navigate" is non-deterministic in production - and completely unreproducible in my local dev environment.  What I believe it relates to is some timing issue with the list of course packages loading when visiting the "All Courses" view - and somehow that interleaving or interrupting the dispatch or receipt of a redux action that is designed to clear the global redux state of the "current course".

A bit of background: when you are in a course and when you navigate back to the "All courses" page, several actions are dispatched.  One of them is the action created by `enterApplicationView` in `src/actions/router.ts`, line 47.  This message is received in the course reducer (`src/reducers/course.ts` line 29) where it simply resets the state of the `course` slice to be null.  The `Header.tsx` component displays either the course name or the name of the application, depending upon whether that `course` slice of global state is null or whether it points to a course. 

So what I believe is happening is somehow that `ENTER_APPLICATION_VIEW` message is not being dispatched or not being handled, or somehow its result (of setting `course` to `null`) is being overwritten. 

Since I could not identify and address the root cause, I sought a way to avoid it.  What I came up with was to change the `Header.tsx` component to base its display off the *actual route* and not simply the presence of a course.  That way, when we have navigated back to "All Courses" and if there still is a `course` hanging around the header display will be correct.   

Also, I changed the way that courses are entered from a button that dispatches an event to simply a link that drives browser history.  

The net effect of all of this (tested on shattrath) is that I can now no longer reproduce the problem.

RISK: Low/Medium,  fairly straightforward changes but the change to using a direct link carries a bit of risk I guess
STABILIY: Medium, seems like it fixes the issue

