### PR TITLE
Attempt to fix the analytics refresh issue when viewing analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.12",
+  "version": "0.43.13",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/document/analytics/Analytics.tsx
+++ b/src/editors/document/analytics/Analytics.tsx
@@ -184,7 +184,7 @@ export interface AnalyticsState {
  * Analytics React Component
  */
 class Analytics
-  extends React.PureComponent<StyledComponentProps<AnalyticsProps, typeof styles>,
+  extends React.Component<StyledComponentProps<AnalyticsProps, typeof styles>,
   AnalyticsState> {
 
   constructor(props) {
@@ -201,10 +201,21 @@ class Analytics
     nextProps: Readonly<AnalyticsProps>, nextState: Readonly<AnalyticsState>) {
     // this assumes that aggregateModel, skills, objectives are all set together
     if (nextProps.model !== null
-      && nextProps.model !== this.props.model) {
+      && nextProps.model.id !== this.props.model.id) {
       this.fetchResources(nextProps);
       this.setState(this.getDefaultState());
     }
+  }
+
+  shouldComponentUpdate(nextProps: Readonly<StyledComponentProps<AnalyticsProps, JSSStyles>>,
+    nextState: Readonly<AnalyticsState>) {
+    return nextState !== this.state ||
+      nextProps.course.idvers !== this.props.course.idvers ||
+      nextProps.model.id !== this.props.model.id ||
+      nextProps.analytics !== this.props.analytics ||
+      nextProps.objectives !== this.props.objectives ||
+      nextProps.skills !== this.props.skills ||
+      nextProps.organization.id !== this.props.organization.id;
   }
 
   getDefaultState = () => {


### PR DESCRIPTION
There's a problem when viewing analytics on some courses where the page will flicker and the analytics tab will constantly refresh as it re-renders. This is an attempt to fix that, though it's hard to test locally. The plan is to either deploy to Shattrath and get a course with a dataset up, or if not, deploy to Echo to keep an eye on and test (the changes are restricted to the analytics tab).

Changes:
`componentWillReceiveProps`: only consider changes when the `model` (the currently viewed organization item) has a different ID
`componentShouldUpdate`: only re-render when state changes or one of the "main" props change