### PR TITLE
Preserve em-styled text in list items without paragraphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.16",
+  "version": "0.43.17",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -68,6 +68,12 @@ export function toSlate(
   return Value.fromJSON(json);
 }
 
+// true of inline pieces that can be collected within an enclosing paragraph
+function inlinePiece(e: any) : boolean {
+  const key = common.getKey(e);
+  return marks.contains(key) || inlineHandlers[key] !== undefined || key === '#text';
+}
+
 // Normalize the sometimes strange format of the input to an array of blocks
 function normalizeInput(toParse, isInlineText: boolean): Object[] {
 
@@ -81,15 +87,18 @@ function normalizeInput(toParse, isInlineText: boolean): Object[] {
     return [{ p: { '#array': [toParse] } }];
   }
 
-  // Normalize the case where all entries are either a
-  // mark or inline.  This can happen with choice bodies, where we strip
-  // out the outer paragraph on one paragraph long choice bodies.
   if (toParse instanceof Array) {
-    if (toParse.every((e) => {
-      const key = common.getKey(e);
-      const canMerge = marks.contains(key) || inlineHandlers[key] !== undefined || key === '#text';
-      return canMerge;
-    })) {
+    // Normalize the case where a single entry exists - and that entry is a
+    // mark or inline.  This can happen with choice bodies, where we strip
+    // out the outer paragraph on one paragraph long choice bodies.
+    if (toParse.length === 1) {
+      const key = common.getKey(toParse[0]);
+      if (marks.contains(key) || inlineHandlers[key] !== undefined) {
+        return [{ p: { '#array': toParse } }];
+      }
+    } else if (toParse.every(inlinePiece)) {
+      // (AUTHORING-2324) wrap up multiple inline pieces including #text. This
+      // can arise from styled complex list item content not wrapped in paragraph
       return [{ p: { '#array': toParse } }];
     }
   }

--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -81,18 +81,20 @@ function normalizeInput(toParse, isInlineText: boolean): Object[] {
     return [{ p: { '#array': [toParse] } }];
   }
 
-  // Normalize the case where a single entry exists - and that entry is a
+  // Normalize the case where all entries are either a
   // mark or inline.  This can happen with choice bodies, where we strip
   // out the outer paragraph on one paragraph long choice bodies.
-  if (toParse instanceof Array && toParse.length === 1) {
-    const key = common.getKey(toParse[0]);
-    if (marks.contains(key) || inlineHandlers[key] !== undefined) {
+  if (toParse instanceof Array) {
+    if (toParse.every((e) => {
+      const key = common.getKey(e);
+      const canMerge = marks.contains(key) || inlineHandlers[key] !== undefined || key === '#text';
+      return canMerge;
+    })) {
       return [{ p: { '#array': toParse } }];
     }
   }
 
   return toParse;
-
 }
 
 // Handle parsing of a block based off of a registry of

--- a/test/data/models/li-no-paragraph-test.ts
+++ b/test/data/models/li-no-paragraph-test.ts
@@ -1,0 +1,50 @@
+// Unit tests to ensure the content types and model objects correctly
+// serialize to JSON and can correctly deserialize back from JSON
+
+import * as contentTypes from 'data/contentTypes';
+import { WorkbookPageModel } from 'data/models/workbook';
+import { ContiguousText } from 'data/content/learning/contiguous';
+import { registerContentTypes } from 'data/registrar';
+import { ContentElements } from 'data/content/common/elements';
+
+function verifyStringContains(contiguous: ContiguousText, str: string) {
+  contiguous.extractPlainText().caseOf({
+    just: v => expect(v).toContain(str),
+    nothing: () => fail(),
+  });
+}
+
+// Test for bug AUTHORING-2324: verify em-styled text in list item
+// containing sublist is preserved when item content not wrapped in a paragraph
+it('Parse styled list item content not in paragraph (AUTHORING-2324)', () => {
+
+  registerContentTypes();
+
+  const workbookPage = require('./li-no-paragraph.json');
+  const model = WorkbookPageModel.fromPersistence(workbookPage, () => null);
+
+  const body = model.body.content.toArray();
+  expect(body.length).toBe(1);
+  expect(body[0] instanceof contentTypes.Ul).toBe(true);
+  const ul = body[0] as contentTypes.Ul;
+
+  // console.log(JSON.stringify(ul, (k,v) => k === 'supportedElements' ? undefined : v, 4));
+
+  const listItems = ul.listItems.toArray();
+  expect(listItems.length).toBe(1);
+  expect(listItems[0] instanceof contentTypes.Li).toBe(true);
+  const item = listItems[0] as contentTypes.Li;
+
+  const itemContentElements  = item.content as ContentElements;
+  const itemContents = itemContentElements.content.toArray();
+
+  // Contents should consist of a ContiguousText followed by a nested UL
+  expect(itemContents.length).toBe(2);
+  expect(itemContents[0] instanceof ContiguousText).toBe(true);
+  expect(itemContents[1] instanceof contentTypes.Ul).toBe(true);
+  const itemText = itemContents[0] as ContiguousText;
+
+  // cheap test for bug fix: make sure em-tagged text was not deleted from li's content
+  verifyStringContains(itemText, 'Emphasized');
+});
+

--- a/test/data/models/li-no-paragraph.json
+++ b/test/data/models/li-no-paragraph.json
@@ -1,0 +1,62 @@
+{
+  "rev": 1,
+  "guid": "2c9b80865c1b77b4015c1b79bc2c0003",
+  "id": "workbook",
+  "type": "x-oli-workbook_page",
+  "title": "This is the title",
+  "shortTitle": null,
+  "lastRevision": {
+    "rev": 0,
+    "guid": "d98f2aeaa7ba404aae91d6d690dba5d3",
+    "revisionNumber": 17,
+    "previousRevision": "2b5091113974410b90c9c9cf93173ccc",
+    "md5": "3bb097cc20247872debfce4e8e6ea83f",
+    "author": "manager",
+    "revisionType": "SYSTEM",
+    "dateCreated": "Jan 25, 2019 10:16:08 PM",
+    "dateUpdated": "Jan 25, 2019 10:16:08 PM"
+  },
+  "doc": {
+    "workbook_page": {
+      "@id": "workbook",
+      "#array": [
+        {
+          "head": {
+            "#array": [
+              {
+                "title": {
+                  "#text": "This is the title"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "body": {
+            "ul": {
+              "li": {
+                "#array": [
+                  {
+                    "em": {
+                      "#text": "Emphasized "
+                    }
+                  },
+                  {
+                    "#text": " OuterList Item "
+                  },
+                  {
+                    "ul": {
+                      "li": {
+                        "#text": "InnerItem"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adjusts content parser to handle the case of AUTHORING-2324 in which em-tagged text pieces within complex list items were getting deleted. It also adds a unit test for this case. 

The bug arose in the case of a list item containing some partially styled text along with a nested ul, without wrapping its content in a paragraph. A sample case:

```
<ul>
        <li><em>Emphasized </em> OuterList Item
                <ul >
                        <li>InnerItem</li>
                </ul>
        </li>
</ul>
```
