### PR TITLE
edit Extra with audio or translation as definition. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.18",
+  "version": "0.43.19",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/extra.ts
+++ b/src/data/content/learning/extra.ts
@@ -113,7 +113,11 @@ export class Extra extends Immutable.Record(defaultContent) {
   }
 
   isDefinition() : boolean {
-    return this.meaning.size > 0;
+    const hasAudio = this.pronunciation.src.valueOr('').trim() !== '';
+    const hasTranslation = this.translation.content.extractPlainText().valueOr('').trim() !== '';
+    const hasMeaning = this.meaning.size > 0;
+
+    return hasMeaning || hasAudio || hasTranslation;
   }
 
   toPersistence() : Object {

--- a/src/editors/content/learning/ExtraDefinitionEditor.tsx
+++ b/src/editors/content/learning/ExtraDefinitionEditor.tsx
@@ -212,11 +212,18 @@ class ExtraDefinitionEditor
   }
 
   onSaveChanges() {
+
     // partial update to avoid clobbering pronunciation, may have been updated from sidebar
-    const newModel = this.props.model.with({
-      translation: this.state.model.translation,
-      meaning: this.state.model.meaning,
-    });
+    const newModel =
+      this.props.model.isDefinition()
+        ? this.props.model.with({
+          translation: this.state.model.translation,
+          meaning: this.state.model.meaning,
+        })
+        : this.props.model.with({
+          content: this.state.model.content,
+        });
+
     this.props.onEdit(newModel);
     this.props.onClose();
   }
@@ -281,6 +288,8 @@ class ExtraDefinitionEditor
       />
       : null;
 
+    const separator = this.state.model.meaning.size > 0 ? <div><b>OR</b><br/></div> : null;
+
     return (
       <div className={classNames([classes.definition, className])}>
 
@@ -290,7 +299,7 @@ class ExtraDefinitionEditor
 
         {meaningEditors}
 
-        <br/><b>OR</b><br/><br/>
+        {separator}
 
         {translationEditor}
 


### PR DESCRIPTION
Change to treat Extra's with only audio or translation but no meaning elements as Rollover Definitions. These occur in PIMA French XML. Need to treat as Definitions so can view/add/edit the translation or audio pieces.

One odd effect with this change is that if you load an Extra with translation only in the XML and clear the translation content, it now has no content to determine it to be a definition and reverts to being treated as Rollover Content, and you can't add translation back in. You just have to delete the anchor text and start a new Rollover Definition. Expect this will be rare. 

Also fix to properly save changes for the case of Rollover Content. Seems this had been broken since the rollover Definition editor was enhanced, apparently unnoticed. 

