### PR TITLE
Prevent org switch on loading page from resource view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.19",
+  "version": "0.43.20",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/models/org.ts
+++ b/src/data/models/org.ts
@@ -97,7 +97,7 @@ export class OrganizationModel extends Immutable.Record(defaultOrganizationModel
       org = a.doc.organization;
     }
 
-    model = setId(model, a, notify);
+    model = setId(model, org, notify);
 
     if (org['@version'] !== undefined) {
       model = model.with({ version: org['@version'] });


### PR DESCRIPTION
Corrects a small coding error in organization fromPersistence. Error caused new guid to be set into the id field whenever loading an org model. Evidently did not affect very much  -- code initiating a load would already have the correct id in some variable so wouldn't need to fetch it from the corrupted model. But was responsible for AUTHORING-2329. URLS in page links on ResourceView picked up a bad orgId from the model, so opening a resource from resource view always caused reversion to default org.