### PR TITLE
Prevent looping "session expired" popup on read-only pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.21",
+  "version": "0.43.22",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/manager/EditorManager.tsx
+++ b/src/editors/manager/EditorManager.tsx
@@ -60,9 +60,11 @@ export default class EditorManager
 
   onEdit(model: models.ContentModel) {
 
-    const { onSave, documentId } = this.props;
+    const { onSave, documentId, editingAllowed } = this.props;
 
-    onSave(documentId, model);
+    if (editingAllowed) {
+      onSave(documentId, model);
+    }
   }
 
   determineBaseUrl(resource: Resource) {


### PR DESCRIPTION
This blocks saving a read-only document to fix endlessly looping in the "Session expired" popup that comes up on save failures due to missing lock. 

Fresh load of a document almost always triggers a save (as can be seen from the "all changes saved" message you get), apparently because the process of putting content into the slate editor generates change notifications. Code at the EditorManager level was not checking if document was read-only before saving. So once this popup came up, reloading from the "Refresh" button in the popup would trigger a repeat of the failure and popup.

With this change, if you open the document readonly the popup should not appear. If you open non-readonly and someone else acquires the lock during the session, an attempted change will get the popup once (which is appropriate). Then hitting "refresh" will reload the document with the read-only message along the top. 