### PR TITLE
Hide xref target window choice

### DIFF
--- a/src/data/content/workbook/xref.ts
+++ b/src/data/content/workbook/xref.ts
@@ -15,7 +15,7 @@ export type XrefParams = {
 const defaultContent = {
   contentType: 'Xref',
   elementType: 'xref',
-  target: 'self',
+  target: 'new',
   idref: '',
   page: '',
   title: '',

--- a/src/editors/content/learning/XrefEditor.tsx
+++ b/src/editors/content/learning/XrefEditor.tsx
@@ -211,16 +211,18 @@ export default class XrefEditor
           <Target {...this.props} targetIsPage={this.state.targetIsPage} target={target}
             onChangeTarget={this.onChangeTarget} />
         </SidebarGroup>
-        <SidebarGroup label="On Click">
-          <Select
-            editMode={editMode}
-            value={model.target}
-            onChange={v =>
-              onEdit(model.with({ target: v === 'self' ? LinkTarget.Self : LinkTarget.New }))}>
-            <option value={LinkTarget.Self}>Open in this window</option>
-            <option value={LinkTarget.New}>Open in new window</option>
-          </Select>
-        </SidebarGroup>
+        {false &&  // hide b/c delivery ignores this setting (always opens in new popup)
+          <SidebarGroup label="On Click">
+            <Select
+              editMode={editMode}
+              value={model.target}
+              onChange={v =>
+                onEdit(model.with({ target: v === 'self' ? LinkTarget.Self : LinkTarget.New }))}>
+              <option value={LinkTarget.Self}>Open in this window</option>
+              <option value={LinkTarget.New}>Open in new window</option>
+            </Select>
+          </SidebarGroup>
+        }
       </SidebarContent>
     );
   }


### PR DESCRIPTION
This hides the target window choice in the xref sidebar, because the legacy delivery system doesn't handle this option (themes produce code to open xrefs in new medium-sized popup window). 