### PR TITLE
load css files for pinned mathlive version

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
   integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 
+  <!-- MathLive css for math input questions !-->
+  <!-- use fixed version matching script version we customized-->
+  <link href="https://unpkg.com/mathlive@0.50.7/dist/mathlive.core.css" type="text/css" rel="stylesheet"/>
+  <link href="https://unpkg.com/mathlive@0.50.7/dist/mathlive.css" type="text/css" rel="stylesheet"/>
+
 
 
 <% for (var css in htmlWebpackPlugin.files.css) { %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.23",
+  "version": "0.43.24",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",


### PR DESCRIPTION
This loads mathlive css files for mathlive version 0.50.7, matching the version used by delivery. Needed for proper rendering of the MathLive Preview widget shown when authoring a math input question. 

(The MathLive Preview component is shown to enable the author to use the same MathLive keyboard the students will see to construct a mathematical expression and then copy the generated LaTex for use as an answer match.)