### PR TITLE
fix glitch preventing xref to text block element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.24",
+  "version": "0.43.25",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/contiguous.ts
+++ b/src/data/content/learning/contiguous.ts
@@ -147,7 +147,7 @@ export class ContiguousText extends Immutable.Record(defaultContent) {
 
   // Return the OLI ID of the first paragraph in the text block
   getFirstReferenceId(): string | undefined {
-    const firstBlock = this.slateValue.document.nodes[0];
+    const firstBlock = this.slateValue.document.nodes.first() as Block;
     if (firstBlock) {
       return firstBlock.data.get('id');
     }


### PR DESCRIPTION
This fixes a coding error which prevented Echo from finding the id for a cross-reference link to a TextBlock element on a page.   There is no JIRA issue for this, it was discovered while working on a different bug.