### PR TITLE
Prevent invalid xrefs from being saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.25",
+  "version": "0.43.26",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/editors/content/learning/XrefEditor.tsx
+++ b/src/editors/content/learning/XrefEditor.tsx
@@ -145,15 +145,14 @@ export default class XrefEditor
   onChangePage(page: string) {
 
     const { onEdit, model, updateTarget } = this.props;
-    if (this.state.targetIsPage) {
-      onEdit(model.with({ page, idref: page }));
-    } else {
-      onEdit(model.with({ page }));
+    onEdit(model.with({ page, idref: page }));
+    if (!this.state.targetIsPage) {
+      // To avoid invalid xref state (unbuildable if written out),
+      // a page change from element target resets to whole page target.
+      this.setState({ targetIsPage: true});
+      setTimeout(() => updateTarget(model.page, model.page), 0);
     }
-    // Search for the target element in the new page
-    if (model.idref) {
-      setTimeout(() => updateTarget(model.idref, page), 0);
-    }
+
   }
 
   onToggleTargetPage(targetIsPage: boolean) {
@@ -162,7 +161,7 @@ export default class XrefEditor
     this.setState({ targetIsPage });
     if (targetIsPage) {
       onEdit(model.with({ idref: model.page }));
-      setTimeout(() => updateTarget(model.idref, model.page), 0);
+      setTimeout(() => updateTarget(model.page, model.page), 0);
     }
   }
 

--- a/src/editors/content/learning/XrefEditor.tsx
+++ b/src/editors/content/learning/XrefEditor.tsx
@@ -149,7 +149,7 @@ export default class XrefEditor
     if (!this.state.targetIsPage) {
       // To avoid invalid xref state (unbuildable if written out),
       // a page change from element target resets to whole page target.
-      this.setState({ targetIsPage: true});
+      this.setState({ targetIsPage: true });
       setTimeout(() => updateTarget(model.page, model.page), 0);
     }
 

--- a/src/editors/content/learning/XrefEditor.tsx
+++ b/src/editors/content/learning/XrefEditor.tsx
@@ -280,7 +280,7 @@ const Target = ({ target, editMode, clipboard, onChangeTarget, targetIsPage }: T
     <div className="target__container">
       <div className="target__instructions">
         <small>
-          1. Open the target page in a new tab.
+          1. Open the target page.
         </small>
         <br />
         <small>
@@ -290,7 +290,7 @@ const Target = ({ target, editMode, clipboard, onChangeTarget, targetIsPage }: T
         </small>
         <br />
         <small>
-          3. Use the button to link to the copied element.
+          3. Click this button to link to the copied element:
         </small>
       </div>
       <Button editMode={editMode && validItemCopied} onClick={onChangeTarget}>


### PR DESCRIPTION
This adjusts the XRefEditor to prevent a situation in which invalid xrefs can wind up saved, breaking the package build. An invalid xref could be saved by (1) creating an xref to a particular element on a page, and then (2)changing the target page in the xref editor. The editor would display that the target is not found, but still write out an invalid xref to a target element that does not exist on the relevant page.

This changes the editor so that changing the page in this case resets the xref to link to the whole page until a new particular element target is set by the editor procedure. 

This also modifies the on-screen instructions to take out the instruction to open the target in a new tab, since opening in a new tab did not seem to work. 