### PR TITLE
fix toSlate parser to handle cdata inside mark (for code tag)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "course-editor",
-  "version": "0.43.25",
+  "version": "0.43.26",
   "description": "Course Authoring Web Application for the Open Learning Initiative",
   "main": "./src/app.tsx",
   "author": "Carnegie Mellon University",

--- a/src/data/content/learning/slate/toslate.ts
+++ b/src/data/content/learning/slate/toslate.ts
@@ -121,10 +121,10 @@ function handleBlock(item: Object, json: ValueJSON, backingTextProvider: Object)
 }
 
 // Given a style mark object, determine if it is the parent of
-// another, nested mark.  A regular mark would have a #text attr,
-// so we simply check for that to be undefined.
+// another, nested mark.  A regular mark would have either a #text
+// or #cdata attr, so we simply check that neither is defined.
 function isNestedMark(item: Object): boolean {
-  return item['#text'] === undefined;
+  return item['#text'] === undefined && item['#cdata'] === undefined;
 }
 
 // Given a style mark object, determine if it is empty, that is it
@@ -345,9 +345,11 @@ function processMark(item: Object,
       return;
     }
 
+    // terminal mark should have unmarked text in either #cdata or #text attr
+    const itemText = item['#cdata'] !== undefined ? item['#cdata'] : item['#text'];
     parent.nodes.push({
       object: 'text',
-      text: item['#text'],
+      text: itemText,
       marks: previousMarks.toArray(),
     });
 


### PR DESCRIPTION
This fixes the toSlate contiguous text parser to handle the case of cdata within a "mark", now being used for inline code. 

A couple of places in the code incorrectly assumed text would be in the "#text" attribute of a terminal mark (one with no subsidiary marks). But the text can be in EITHER a #text attribute OR a #cdata attribute, though the #cdata option was apparently not used before now.  